### PR TITLE
Implement "window" connection and messaging (ChrOS)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@
     ])
       .pipe( babel({
         presets: [ "env" ],
+        plugins: [ "transform-object-assign" ]
       }))
       .pipe( gulp.dest( "dist" ))
       .pipe( sourcemaps.init())

--- a/package-lock.json
+++ b/package-lock.json
@@ -989,6 +989,15 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-object-assign": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
+      "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/Rise-Vision/common-template#readme",
   "devDependencies": {
     "babel-core": "^6.26.3",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.7.0",
     "del": "^3.0.0",
     "eslint": "^5.6.0",

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -1,8 +1,8 @@
-/* global describe, it, expect */
+/* global describe, it, expect, afterEach, beforeEach, sinon */
 
 "use strict";
 
-describe( "configure", function() {
+describe( "configure()", function() {
 
   it( "should not attempt to configure if player type is unsupported", function() {
     RisePlayerConfiguration.LocalMessaging.configure({ player: "test" });
@@ -29,10 +29,127 @@ describe( "configure", function() {
   });
 
   it( "should attempt to configure if connection type is 'window'", function() {
-    RisePlayerConfiguration.LocalMessaging.configure({ player: "electron", connectionType: "window" });
+    RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
 
     expect( RisePlayerConfiguration.LocalMessaging.getConnectionType()).to.equal( "window" );
   });
 
+});
+
+describe( "window connection", function() {
+
+  afterEach( function() {
+    delete top.postToPlayer;
+    delete top.receiveFromPlayer;
+  });
+
+  it( "should not be connected if window to player messaging not available", function( done ) {
+    var connectionHandler = function( evt ) {
+      expect( RisePlayerConfiguration.LocalMessaging.isConnected()).to.be.false;
+      expect( evt.detail ).to.deep.equal({ isConnected: false });
+
+      window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
+
+      done();
+    };
+
+    window.addEventListener( "rise-local-messaging-connection", connectionHandler );
+
+    RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+
+  });
+
+  it( "should be connected if window to player messaging available", function( done ) {
+    var connectionHandler = function( evt ) {
+      expect( RisePlayerConfiguration.LocalMessaging.isConnected()).to.be.true;
+      expect( evt.detail ).to.deep.equal({ isConnected: true });
+
+      window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
+
+      done();
+    };
+
+    top.postToPlayer = function() {};
+    top.receiveFromPlayer = function() {};
+
+    window.addEventListener( "rise-local-messaging-connection", connectionHandler );
+
+    RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+  });
+
+  describe( "receiveMessages", function() {
+
+    beforeEach( function() {
+      top.postToPlayer = function() {};
+      top.receiveFromPlayer = function( name, handler ) {
+        // force test a message
+        handler({ topic: "TEST" });
+      };
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+    });
+
+    afterEach( function() {
+      delete top.postToPlayer;
+      delete top.receiveFromPlayer;
+    });
+
+    it( "should execute handler when message is received", function() {
+      var spy = sinon.spy();
+
+      RisePlayerConfiguration.LocalMessaging.receiveMessages( spy );
+
+      expect( spy ).to.have.been.calledWith({ topic: "TEST" });
+    });
+  });
+
+  describe( "broadcastMessage", function() {
+
+    beforeEach( function() {
+      top.postToPlayer = sinon.spy();
+      top.receiveFromPlayer = function() {};
+    });
+
+    afterEach( function() {
+      delete top.postToPlayer;
+      delete top.receiveFromPlayer;
+    });
+
+    it( "should not attempt to post to player if no message provided", function() {
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage();
+
+      expect( top.postToPlayer ).to.not.have.been.called;
+    });
+
+    it( "should not attempt to broadcast if no connection available", function() {
+      delete top.receiveFromPlayer;
+
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage({ topic: "TEST" });
+
+      expect( top.postToPlayer ).to.not.have.been.called;
+    });
+
+    it( "should broadcast message to player with default client name", function() {
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage({ topic: "TEST" });
+
+      expect( top.postToPlayer ).to.have.been.calledWith({ topic: "TEST", from: "ws-client" });
+    });
+
+    it( "should broadcast message to player with configured client name", function() {
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window", detail: { clientName: "test-client" } });
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage({ topic: "TEST" });
+
+      expect( top.postToPlayer ).to.have.been.calledWith({ topic: "TEST", from: "test-client" });
+    });
+
+    it( "should be able to handle a String for message param", function() {
+      RisePlayerConfiguration.LocalMessaging.configure({ player: "chromeos", connectionType: "window" });
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage( "TEST" );
+
+      expect( top.postToPlayer ).to.have.been.calledWith({ msg: "TEST", from: "ws-client" });
+    });
+  });
 
 });


### PR DESCRIPTION
- Determines connection success based on `top.postToPlayer` and `top.receiveFromPlayer` function being available.
- `window` dispatches custom event _rise-local-messaging-connection_ event with `{isConnected: Boolean}` detail upon determining if connection is available
- `broadcastMessage()` and `receiveMessages()` added and applied for "window" messaging
- If `detail` provided in `configure()` and it includes `clientName`, then this value is applied when a message is broadcast. Otherwise the default "ws-client" client name is used. 