### PR TITLE
Implement messaging for “websocket” connection

### DIFF
--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -54,7 +54,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
 
   function _disconnectViewerConnection() {
     try {
-      if ( top.RiseVision.Viewer.LocalMessaging ) {
+      if ( top.RiseVision && top.RiseVision.Viewer && top.RiseVision.Viewer.LocalMessaging ) {
         top.RiseVision.Viewer.LocalMessaging.disconnect();
       }
     } catch ( err ) {
@@ -189,7 +189,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function configure( data ) {
-    const { player, connectionType, detail = { clientName: DEFAULT_CLIENT_NAME } } = data;
+    const { player, connectionType, detail = {} } = data;
 
     // automated testing purposes
     _resetForAutomatedTests();
@@ -209,7 +209,9 @@ RisePlayerConfiguration.LocalMessaging = (() => {
       return;
     }
 
-    _clientName = detail.clientName;
+    let details = Object.assign({}, { clientName: DEFAULT_CLIENT_NAME }, detail );
+
+    _clientName = details.clientName;
 
     switch ( connectionType ) {
     case "websocket":

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -30,6 +30,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
       console.log( "local messaging disconnected" );
 
       _connected = false;
+      _sendConnectionEvent();
     });
 
     _connection.on( "error", ( error ) => {


### PR DESCRIPTION
- Temporarily bypassing the dynamic load/append of the Primus client side library script due to all Rise Players still using Viewer. 
- Expecting `serverUrl` provided in `detail` object of `configure()` function when configuring for websocket connection
- Disconnects existing connection already made in Viewer (**Note** This is untested)
- Establishes a websocket connection via Primus and handles all relevant websocket events
- `window` dispatches custom event _rise-local-messaging-connection_ event with `{isConnected: Boolean}` detail upon connection status. Allowing for 20 seconds to establish the connection before sending the event. 
- Logic applied for`broadcastMessage()` and `receiveMessages()` for "websocket" messaging
