### PR TITLE
Chore/deploy to gcs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
           gsutil acl -r ch -u AllUsers:R $TARGET
 
 workflows:
-  version: 2.1
   workflow1:
     jobs:
       - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^feature[/].*/
+                - /^chore[/].*/
                 - master
                 - build/stable
       - deploy_to_gcs:
@@ -66,7 +66,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^feature[/].*/
+                - /^chore[/].*/
                 - master
                 - build/stable
       - deploy_to_gcs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ workflows:
           filters:
             branches:
               only:
-                - /^chore[/].*/
                 - master
                 - build/stable
       - deploy_to_gcs:
@@ -66,9 +65,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^chore[/].*/
                 - master
-                - build/stable
       - deploy_to_gcs:
           stage: stable
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
   workflow1:
     jobs:
       - build_and_test
-      - gcloud_setup
+      - gcloud_setup:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,29 @@ workflows:
     jobs:
       - build_and_test
       - gcloud_setup
+          filters:
+            branches:
+              only:
+                - /^feature[/].*/
+                - master
+                - build/stable
       - deploy_to_gcs:
           stage: beta
           requires:
             - build_and_test
             - gcloud_setup
+          filters:
+            branches:
+              only:
+                - /^feature[/].*/
+                - master
+                - build/stable
+      - deploy_to_gcs:
+          stage: stable
+          requires:
+            - build_and_test
+            - gcloud_setup
+          filters:
+            branches:
+              only:
+                - build/stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ jobs:
       - run: sudo npm install -g gulp
       - run: npm install
       - run: npm test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
 
   gcloud_setup:
     docker: &GCSIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,43 @@ jobs:
       - run: npm install
       - run: npm test
 
+  gcloud_setup:
+    docker: &GCSIMAGE
+      - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+    steps:
+      - run: mkdir -p ~/.ssh
+      - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git clone git@github.com:Rise-Vision/private-keys.git
+      - run: mv private-keys ..
+      - run: gcloud auth activate-service-account 452091732215@developer.gserviceaccount.com --key-file ../private-keys/storage-server/rva-media-library-ce0d2bd78b54.json
+      - persist_to_workspace:
+          root: ~/.config
+          paths:
+            - gcloud
+
+  deploy_beta:
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: |
+          TARGET=gs://widgets.risevision.com/beta
+          gsutil cp dist/*.js $TARGET
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+          gsutil acl -r ch -u AllUsers:R $TARGET
+
 workflows:
   version: 2
   workflow1:
     jobs:
       - build_and_test
+      - gcloud_setup
+      - deploy_beta:
+          requires:
+            - build_and_test
+            - gcloud_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   build_and_test:
@@ -28,7 +28,10 @@ jobs:
           paths:
             - gcloud
 
-  deploy_beta:
+  deploy_to_gcs:
+    parameters:
+      stage:
+        type: string
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -39,18 +42,19 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          TARGET=gs://widgets.risevision.com/beta
+          TARGET=gs://widgets.risevision.com/<< parameters.stage >>/common
           gsutil cp dist/*.js $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
 
 workflows:
-  version: 2
+  version: 2.1
   workflow1:
     jobs:
       - build_and_test
       - gcloud_setup
-      - deploy_beta:
+      - deploy_to_gcs:
+          stage: beta
           requires:
             - build_and_test
             - gcloud_setup


### PR DESCRIPTION
Deploys the common-template scripts to GCS for master and stable branches.

It uploads the code under dist/ to either gs://widgets.risevision.com/beta/common or gs://widgets.risevision.com/stable/common depending on the branch.

Manually tested for the beta stage:
https://console.cloud.google.com/storage/browser/widgets.risevision.com/beta/common
