### PR TITLE
Feature/watch single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # common-template
 Common scripts for Rise Templates
+
+## Build
+
+`
+npm install -g gulp
+npm install
+gulp build
+`
+
+Output scripts will be placed in dist/ directory
+
+## Test
+
+`
+gulp test
+`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@
 
   gulp.task( "scripts", () => {
     return gulp.src([
+      "src/rise-helpers.js",
       "src/rise-local-messaging.js",
       "src/rise-local-storage.js",
       "src/rise-player-configuration.js"
@@ -45,6 +46,7 @@
       "test/test_env.js",
       "dist/rise-player-configuration.js",
       "dist/rise-local-messaging.js",
+      "dist/rise-helpers.js",
       "dist/rise-local-storage.js",
       "test/unit/*test.js" ] }
   ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@
   gulp.task( "scripts", () => {
     return gulp.src([
       "src/rise-local-messaging.js",
+      "src/rise-local-storage.js",
       "src/rise-player-configuration.js"
     ])
       .pipe( babel({
@@ -44,6 +45,7 @@
       "test/test_env.js",
       "dist/rise-player-configuration.js",
       "dist/rise-local-messaging.js",
+      "dist/rise-local-storage.js",
       "test/unit/*test.js" ] }
   ));
 

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-console, one-var */
+
+RisePlayerConfiguration.Helpers = (() => {
+
+  let _clients = [];
+
+  function _clientsAreAvailable( names ) {
+    return names.every( name => _clients.indexOf( name ) >= 0 );
+  }
+
+  function onceClientsAreAvailable( requiredClientNames, action ) {
+    let invoked = false;
+    const names = typeof requiredClientNames === "string" ?
+      [ requiredClientNames ] : requiredClientNames;
+    const playerType = RisePlayerConfiguration.LocalMessaging.getPlayerType();
+
+    if ( playerType !== "electron" || _clientsAreAvailable( names )) {
+      return action();
+    }
+
+    RisePlayerConfiguration.LocalMessaging.receiveMessages( message => {
+      if ( invoked || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
+        return;
+      }
+
+      _clients = message.clients;
+
+      if ( _clientsAreAvailable( names )) {
+        invoked = true;
+        action();
+      }
+    });
+
+    RisePlayerConfiguration.LocalMessaging.broadcastMessage({
+      topic: "client-list-request"
+    });
+  }
+
+  function reset() {
+    _clients = [];
+  }
+
+  return {
+    onceClientsAreAvailable: onceClientsAreAvailable,
+    reset: reset
+  }
+
+})();

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -11,7 +11,6 @@ RisePlayerConfiguration.LocalMessaging = (() => {
     _connectionType,
     _playerType,
     _initialWebsocketConnectionTimer = null,
-    _clients = [],
     _messageHandlers = [];
 
   function _addWebsocketConnectionHandlers() {
@@ -157,12 +156,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
     _connection = undefined;
     _connectionType = undefined;
     _playerType = undefined;
-    _clients = [];
     _messageHandlers = [];
-  }
-
-  function _clientsAreAvailable( names ) {
-    return names.every( name => _clients.indexOf( name ) >= 0 );
   }
 
   function _sendConnectionEvent() {
@@ -243,6 +237,10 @@ RisePlayerConfiguration.LocalMessaging = (() => {
     return _connectionType;
   }
 
+  function getPlayerType() {
+    return _playerType;
+  }
+
   function isConnected() {
     return _connected;
   }
@@ -263,38 +261,13 @@ RisePlayerConfiguration.LocalMessaging = (() => {
 
   }
 
-  function onceClientsAreAvailable( requiredClientNames, action ) {
-    let invoked = false;
-    const names = typeof requiredClientNames === "string" ?
-      [ requiredClientNames ] : requiredClientNames;
-
-    if ( _playerType !== "electron" || _clientsAreAvailable( names )) {
-      return action();
-    }
-
-    receiveMessages( message => {
-      if ( invoked || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
-        return;
-      }
-
-      _clients = message.clients;
-
-      if ( _clientsAreAvailable( names )) {
-        invoked = true;
-        action();
-      }
-    });
-
-    broadcastMessage({ topic: "client-list-request" });
-  }
-
   return {
     broadcastMessage: broadcastMessage,
     configure: configure,
     isConnected: isConnected,
     getConnectionType: getConnectionType,
-    receiveMessages: receiveMessages,
-    onceClientsAreAvailable: onceClientsAreAvailable
+    getPlayerType: getPlayerType,
+    receiveMessages: receiveMessages
   }
 
 })();

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -161,8 +161,8 @@ RisePlayerConfiguration.LocalMessaging = (() => {
     _messageHandlers = [];
   }
 
-  function _clientsAreAvailable(names) {
-    return names.every(name => _clients.indexOf(name) >= 0);
+  function _clientsAreAvailable( names ) {
+    return names.every( name => _clients.indexOf( name ) >= 0 );
   }
 
   function _sendConnectionEvent() {
@@ -263,21 +263,23 @@ RisePlayerConfiguration.LocalMessaging = (() => {
 
   }
 
-  function onceClientsAreAvailable(requiredClientNames, action) {
+  function onceClientsAreAvailable( requiredClientNames, action ) {
     let invoked = false;
-    const names = typeof requiredClientNames === 'string' ?
-      [requiredClientNames] : requiredClientNames;
+    const names = typeof requiredClientNames === "string" ?
+      [ requiredClientNames ] : requiredClientNames;
 
-    if (_playerType !== 'electron' || _clientsAreAvailable(names) ) {
+    if ( _playerType !== "electron" || _clientsAreAvailable( names )) {
       return action();
     }
 
     receiveMessages( message => {
-      if (invoked || message.topic.toUpperCase() !== 'CLIENT-LIST') { return; }
+      if ( invoked || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
+        return;
+      }
 
       _clients = message.clients;
 
-      if (_clientsAreAvailable(names)) {
+      if ( _clientsAreAvailable( names )) {
         invoked = true;
         action();
       }

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -7,18 +7,17 @@ RisePlayerConfiguration.LocalStorage = (() => {
       return;
     }
 
-    const available = message.status.toUpperCase() === "CURRENT";
+    const status = message.status.toUpperCase();
 
-    // availability hasn't changed, so don't handle
-    if ( available === state.available ) {
+    if ( status === state.status ) {
       return;
     }
 
-    Object.assign( state, { available, error: false });
+    Object.assign( state, { status, errorMessage: null, errorDetail: null });
 
-    const fileUrl = available ? message.osurl : null;
+    const fileUrl = status === "CURRENT" ? message.osurl : null;
 
-    handler({ fileUrl, available });
+    handler({ fileUrl, status });
   }
 
   function _handleFileError( message, state, handler ) {
@@ -26,24 +25,24 @@ RisePlayerConfiguration.LocalStorage = (() => {
       return;
     }
 
-    // file is not being watched
+    // file is not being wathed
     if ( message.filePath !== state.filePath ) {
       return;
     }
 
-    const available = false;
-    const error = true;
-
-    Object.assign( state, { available, error });
+    state.status = "FILE-ERROR";
 
     handler({
-      available, error, errorMessage: message.msg, errorDetail: message.detail
+      fileUrl: null,
+      status: state.status,
+      errorMessage: message.msg,
+      errorDetail: message.detail
     });
   }
 
   function watchSingleFile( filePath, handler ) {
     RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", () => {
-      const state = { filePath, error: false };
+      const state = { filePath, status: "UNKNOWN", available: false };
 
       RisePlayerConfiguration.LocalMessaging.broadcastMessage({
         topic: "watch", filePath

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -42,7 +42,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
   }
 
   function watchSingleFile( filePath, handler ) {
-    RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", () => {
+    RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", () => {
       const state = { filePath, error: false };
 
       RisePlayerConfiguration.LocalMessaging.broadcastMessage({

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-console */
+
+RisePlayerConfiguration.LocalStorage= (() => {
+
+  function _handleFileUpdate(message, state, handler) {
+    if (!message || !message.filePath || !message.status || message.filePath !== state.filePath) {
+      return;
+    }
+
+    const available = message.status.toUpperCase() === "CURRENT";
+
+    // availability hasn't changed, so don't handle
+    if (available === state.available) {return;}
+
+    Object.assign(state, {available, error: false});
+
+    const fileUrl = available ? message.osurl : null;
+
+    handler({ fileUrl, available });
+  }
+
+  function _handleFileError(message, state, handler) {
+    if (!message || !message.filePath) {return;}
+
+    // file is not being watched
+    if (message.filePath !== state.filePath) {return;}
+
+    const available = false;
+    const error = true;
+    Object.assign(state, {available, error});
+
+    handler({
+      available, error, errorMessage: message.msg, errorDetail: message.detail
+    });
+  }
+
+  function watchSingleFile(filePath, handler) {
+    RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', () =>
+    {
+      const state = {filePath, available: false, error: false};
+
+      RisePlayerConfiguration.LocalMessaging.broadcastMessage({
+        topic: "watch", filePath
+      });
+
+      RisePlayerConfiguration.LocalMessaging.receiveMessages(message => {
+        if (!message || !message.topic) {return;}
+
+        switch (message.topic.toUpperCase()) {
+          case "FILE-UPDATE":
+            return _handleFileUpdate(message, state, handler);
+          case "FILE-ERROR":
+            return _handleFileError(message, state, handler);
+        }
+      });
+    });
+  }
+
+  return {
+    watchSingleFile: watchSingleFile
+  }
+
+})();

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -41,6 +41,12 @@ RisePlayerConfiguration.LocalStorage = (() => {
   }
 
   function watchSingleFile( filePath, handler ) {
+    if ( !RisePlayerConfiguration.LocalMessaging.isConnected()) {
+      console.log( `Conneciton lost, no sending WATCH for ${ filePath }` );
+
+      return;
+    }
+
     RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", () => {
       const state = { filePath, status: "UNKNOWN", available: false };
 

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-RisePlayerConfiguration.LocalStorage= (() => {
+RisePlayerConfiguration.LocalStorage = (() => {
 
   function _handleFileUpdate(message, state, handler) {
     if (!message || !message.filePath || !message.status || message.filePath !== state.filePath) {

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -43,7 +43,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
 
   function watchSingleFile( filePath, handler ) {
     RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", () => {
-      const state = { filePath, available: false, error: false };
+      const state = { filePath, error: false };
 
       RisePlayerConfiguration.LocalMessaging.broadcastMessage({
         topic: "watch", filePath

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -17,7 +17,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
 
     const fileUrl = status === "CURRENT" ? message.osurl : null;
 
-    handler({ fileUrl, status });
+    handler({ filePath: state.filePath, fileUrl, status });
   }
 
   function _handleFileError( message, state, handler ) {
@@ -33,6 +33,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
     state.status = "FILE-ERROR";
 
     handler({
+      filePath: state.filePath,
       fileUrl: null,
       status: state.status,
       errorMessage: message.msg,
@@ -48,7 +49,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
     }
 
     RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", () => {
-      const state = { filePath, status: "UNKNOWN", available: false };
+      const state = { filePath, status: "UNKNOWN" };
 
       RisePlayerConfiguration.LocalMessaging.broadcastMessage({
         topic: "watch", filePath

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -42,7 +42,7 @@ RisePlayerConfiguration.LocalStorage = (() => {
 
   function watchSingleFile( filePath, handler ) {
     if ( !RisePlayerConfiguration.LocalMessaging.isConnected()) {
-      console.log( `Conneciton lost, no sending WATCH for ${ filePath }` );
+      console.log( `Connection lost, no sending WATCH for ${ filePath }` );
 
       return;
     }

--- a/src/rise-local-storage.js
+++ b/src/rise-local-storage.js
@@ -1,56 +1,64 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, one-var */
 
 RisePlayerConfiguration.LocalStorage = (() => {
 
-  function _handleFileUpdate(message, state, handler) {
-    if (!message || !message.filePath || !message.status || message.filePath !== state.filePath) {
+  function _handleFileUpdate( message, state, handler ) {
+    if ( !message || !message.filePath || !message.status || message.filePath !== state.filePath ) {
       return;
     }
 
     const available = message.status.toUpperCase() === "CURRENT";
 
     // availability hasn't changed, so don't handle
-    if (available === state.available) {return;}
+    if ( available === state.available ) {
+      return;
+    }
 
-    Object.assign(state, {available, error: false});
+    Object.assign( state, { available, error: false });
 
     const fileUrl = available ? message.osurl : null;
 
     handler({ fileUrl, available });
   }
 
-  function _handleFileError(message, state, handler) {
-    if (!message || !message.filePath) {return;}
+  function _handleFileError( message, state, handler ) {
+    if ( !message || !message.filePath ) {
+      return;
+    }
 
     // file is not being watched
-    if (message.filePath !== state.filePath) {return;}
+    if ( message.filePath !== state.filePath ) {
+      return;
+    }
 
     const available = false;
     const error = true;
-    Object.assign(state, {available, error});
+
+    Object.assign( state, { available, error });
 
     handler({
       available, error, errorMessage: message.msg, errorDetail: message.detail
     });
   }
 
-  function watchSingleFile(filePath, handler) {
-    RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', () =>
-    {
-      const state = {filePath, available: false, error: false};
+  function watchSingleFile( filePath, handler ) {
+    RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", () => {
+      const state = { filePath, available: false, error: false };
 
       RisePlayerConfiguration.LocalMessaging.broadcastMessage({
         topic: "watch", filePath
       });
 
-      RisePlayerConfiguration.LocalMessaging.receiveMessages(message => {
-        if (!message || !message.topic) {return;}
+      RisePlayerConfiguration.LocalMessaging.receiveMessages( message => {
+        if ( !message || !message.topic ) {
+          return;
+        }
 
-        switch (message.topic.toUpperCase()) {
-          case "FILE-UPDATE":
-            return _handleFileUpdate(message, state, handler);
-          case "FILE-ERROR":
-            return _handleFileError(message, state, handler);
+        switch ( message.topic.toUpperCase()) {
+        case "FILE-UPDATE":
+          return _handleFileUpdate( message, state, handler );
+        case "FILE-ERROR":
+          return _handleFileError( message, state, handler );
         }
       });
     });

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -5,6 +5,12 @@ const RisePlayerConfiguration = {
     if ( !RisePlayerConfiguration.LocalMessaging ) {
       throw new Error( "RiseLocalMessaging script was not loaded" );
     }
+    if ( !RisePlayerConfiguration.LocalStorage ) {
+      throw new Error( "RiseLocalStorage script was not loaded" );
+    }
+    if ( !RisePlayerConfiguration.Helpers ) {
+      throw new Error( "RiseHelpers script was not loaded" );
+    }
 
     RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
 
@@ -13,6 +19,8 @@ const RisePlayerConfiguration = {
     // lock down RisePlayerConfiguration object
     Object.freeze( RisePlayerConfiguration );
   },
+  Helpers: null,
   LocalMessaging: null,
+  LocalStorage: null,
   Logger: null
 };

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -1,0 +1,128 @@
+
+/* global describe, it, expect, afterEach, beforeEach, sinon */
+
+"use strict";
+
+describe( "window connection", function() {
+
+  afterEach( function() {
+    delete top.postToPlayer;
+    delete top.receiveFromPlayer;
+
+    RisePlayerConfiguration.Helpers.reset();
+  });
+
+  describe( "onceClientsAreAvailable", function() {
+    it( "should always invoke the action in ChromeOS player", function() {
+      var spy = sinon.spy();
+
+      RisePlayerConfiguration.LocalMessaging.configure({
+        player: "chromeos", connectionType: "window"
+      });
+
+      RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", spy );
+
+      expect( spy ).to.have.been.called;
+    });
+  });
+
+});
+
+describe( "websocket connection", function() {
+
+  var socketInstance,
+    clock;
+
+  function createSocketInstance() {
+    return {
+      end: sinon.spy(),
+      on: sinon.spy(),
+      write: sinon.spy(),
+      open: sinon.spy()
+    };
+  }
+
+  beforeEach( function() {
+    socketInstance = createSocketInstance();
+    top.PrimusLMS = { connect: function() {} };
+    clock = sinon.useFakeTimers();
+    sinon.stub( top.PrimusLMS, "connect", function( url ) {
+      socketInstance.url = url;
+      return socketInstance;
+    });
+  });
+
+  afterEach( function() {
+    top.PrimusLMS.connect.restore();
+    delete top.PrimusLMS;
+    clock.restore();
+  });
+
+  describe( "onceClientsAreAvailable", function() {
+    var messagingInternalDataHandler;
+
+    beforeEach( function() {
+      var dataHandlerRegistration;
+
+      RisePlayerConfiguration.LocalMessaging.configure({
+        player: "electron",
+        connectionType: "websocket",
+        detail: { serverUrl: "http://localhost:8080" }
+      });
+
+      dataHandlerRegistration = socketInstance.on.args.filter( function( call ) {
+        return call[ 0 ] === "data";
+      })[ 0 ];
+      messagingInternalDataHandler = dataHandlerRegistration[ 1 ];
+    });
+
+    it( "should request the client list if the requested module is not present in player electron", function() {
+      var call = socketInstance.on.args.filter( function( call ) {
+          return call[ 0 ] === "open";
+        })[ 0 ],
+        handler = call[ 1 ];
+
+      handler();
+
+      RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", function() {
+      });
+
+      expect( socketInstance.write ).to.have.been.calledWith({
+        topic: "client-list-request", from: "ws-client"
+      });
+    });
+
+    it( "should invoke the action when local storage module is present", function( done ) {
+      RisePlayerConfiguration.Helpers.onceClientsAreAvailable( "local-storage", done );
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "licensing", "installer"
+        ]
+      });
+    });
+
+    it( "should invoke the action when local storage and licensing modules are present", function( done ) {
+      RisePlayerConfiguration.Helpers.onceClientsAreAvailable([
+        "local-storage", "licensing"
+      ], done );
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "installer"
+        ]
+      });
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "licensing", "installer"
+        ]
+      });
+    });
+
+  });
+
+});

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -152,20 +152,6 @@ describe( "window connection", function() {
     });
   });
 
-  describe( "onceClientsAreAvailable", function() {
-    it( "should always invoke the action in ChromeOS player", function() {
-      var spy = sinon.spy();
-
-      RisePlayerConfiguration.LocalMessaging.configure({
-        player: "chromeos", connectionType: "window"
-      });
-
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", spy );
-
-      expect( spy ).to.have.been.called;
-    });
-  });
-
 });
 
 describe( "websocket connection", function() {
@@ -367,73 +353,6 @@ describe( "websocket connection", function() {
       RisePlayerConfiguration.LocalMessaging.broadcastMessage( "TEST" );
 
       expect( socketInstance.write ).to.have.been.calledWith({ msg: "TEST", from: "ws-client" });
-    });
-
-  });
-
-  describe( "onceClientsAreAvailable", function() {
-    var messagingInternalDataHandler;
-
-    beforeEach( function() {
-      var dataHandlerRegistration;
-
-      RisePlayerConfiguration.LocalMessaging.configure({
-        player: "electron",
-        connectionType: "websocket",
-        detail: { serverUrl: "http://localhost:8080" }
-      });
-
-      dataHandlerRegistration = socketInstance.on.args.filter( function( call ) {
-        return call[ 0 ] === "data";
-      })[ 0 ];
-      messagingInternalDataHandler = dataHandlerRegistration[ 1 ];
-    });
-
-    it( "should request the client list if the requested module is not present in player electron", function() {
-      var call = socketInstance.on.args.filter( function( call ) {
-          return call[ 0 ] === "open";
-        })[ 0 ],
-        handler = call[ 1 ];
-
-      handler();
-
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", function() {
-      });
-
-      expect( socketInstance.write ).to.have.been.calledWith({
-        topic: "client-list-request", from: "ws-client"
-      });
-    });
-
-    it( "should invoke the action when local storage module is present", function( done ) {
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", done );
-
-      messagingInternalDataHandler({
-        topic: "client-list",
-        clients: [
-          "local-storage", "logging", "watchdog", "licensing", "installer"
-        ]
-      });
-    });
-
-    it( "should invoke the action when local storage and licensing modules are present", function( done ) {
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable([
-        "local-storage", "licensing"
-      ], done );
-
-      messagingInternalDataHandler({
-        topic: "client-list",
-        clients: [
-          "local-storage", "logging", "watchdog", "installer"
-        ]
-      });
-
-      messagingInternalDataHandler({
-        topic: "client-list",
-        clients: [
-          "local-storage", "logging", "watchdog", "licensing", "installer"
-        ]
-      });
     });
 
   });

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -154,12 +154,13 @@ describe( "window connection", function() {
 
   describe( "onceClientsAreAvailable", function() {
     it( "should always invoke the action in ChromeOS player", function() {
+      var spy = sinon.spy();
+
       RisePlayerConfiguration.LocalMessaging.configure({
         player: "chromeos", connectionType: "window"
       });
-      var spy = sinon.spy();
 
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', spy);
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", spy );
 
       expect( spy ).to.have.been.called;
     });
@@ -396,7 +397,7 @@ describe( "websocket connection", function() {
 
       handler();
 
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', function(){
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", function() {
       });
 
       expect( socketInstance.write ).to.have.been.calledWith({
@@ -404,8 +405,8 @@ describe( "websocket connection", function() {
       });
     });
 
-    it( "should invoke the action when local storage module is present", function(done) {
-      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', done);
+    it( "should invoke the action when local storage module is present", function( done ) {
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable( "local-storage", done );
 
       messagingInternalDataHandler({
         topic: "client-list",
@@ -415,10 +416,10 @@ describe( "websocket connection", function() {
       });
     });
 
-    it( "should invoke the action when local storage and licensing modules are present", function(done) {
+    it( "should invoke the action when local storage and licensing modules are present", function( done ) {
       RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable([
-        'local-storage', 'licensing'
-      ], done);
+        "local-storage", "licensing"
+      ], done );
 
       messagingInternalDataHandler({
         topic: "client-list",

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -417,7 +417,8 @@ describe( "websocket connection", function() {
 
     it( "should invoke the action when local storage and licensing modules are present", function(done) {
       RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable([
-        'local-storage', 'licensing'], done);
+        'local-storage', 'licensing'
+      ], done);
 
       messagingInternalDataHandler({
         topic: "client-list",

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -152,6 +152,19 @@ describe( "window connection", function() {
     });
   });
 
+  describe( "onceClientsAreAvailable", function() {
+    it( "should always invoke the action in ChromeOS player", function() {
+      RisePlayerConfiguration.LocalMessaging.configure({
+        player: "chromeos", connectionType: "window"
+      });
+      var spy = sinon.spy();
+
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', spy);
+
+      expect( spy ).to.have.been.called;
+    });
+  });
+
 });
 
 describe( "websocket connection", function() {
@@ -357,5 +370,70 @@ describe( "websocket connection", function() {
 
   });
 
+  describe( "onceClientsAreAvailable", function() {
+    var messagingInternalDataHandler;
+
+    beforeEach( function() {
+      var dataHandlerRegistration;
+
+      RisePlayerConfiguration.LocalMessaging.configure({
+        player: "electron",
+        connectionType: "websocket",
+        detail: { serverUrl: "http://localhost:8080" }
+      });
+
+      dataHandlerRegistration = socketInstance.on.args.filter( function( call ) {
+        return call[ 0 ] === "data";
+      })[ 0 ];
+      messagingInternalDataHandler = dataHandlerRegistration[ 1 ];
+    });
+
+    it( "should request the client list if the requested module is not present in player electron", function() {
+      var call = socketInstance.on.args.filter( function( call ) {
+          return call[ 0 ] === "open";
+        })[ 0 ],
+        handler = call[ 1 ];
+
+      handler();
+
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', function(){
+      });
+
+      expect( socketInstance.write ).to.have.been.calledWith({
+        topic: "client-list-request", from: "ws-client"
+      });
+    });
+
+    it( "should invoke the action when local storage module is present", function(done) {
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable('local-storage', done);
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "licensing", "installer"
+        ]
+      });
+    });
+
+    it( "should invoke the action when local storage and licensing modules are present", function(done) {
+      RisePlayerConfiguration.LocalMessaging.onceClientsAreAvailable([
+        'local-storage', 'licensing'], done);
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "installer"
+        ]
+      });
+
+      messagingInternalDataHandler({
+        topic: "client-list",
+        clients: [
+          "local-storage", "logging", "watchdog", "licensing", "installer"
+        ]
+      });
+    });
+
+  });
 
 });

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -5,38 +5,38 @@
 describe( "watchSingleFile", function() {
 
   var DELETED_MESSAGE = {
-    "from":"local-storage",
-    "topic":"FILE-UPDATE",
-    "filePath":"bucket/file.txt",
-    "status":"DELETED",
-    "through":"ws"
+    "from": "local-storage",
+    "topic": "FILE-UPDATE",
+    "filePath": "bucket/file.txt",
+    "status": "DELETED",
+    "through": "ws"
   };
 
   var STALE_MESSAGE = {
-    "from":"local-storage",
-    "topic":"FILE-UPDATE",
-    "filePath":"bucket/file.txt",
-    "status":"STALE",
-    "through":"ws"
+    "from": "local-storage",
+    "topic": "FILE-UPDATE",
+    "filePath": "bucket/file.txt",
+    "status": "STALE",
+    "through": "ws"
   };
 
   var CURRENT_MESSAGE = {
-    "from":"local-storage",
-    "topic":"FILE-UPDATE",
-    "filePath":"bucket/file.txt",
-    "status":"CURRENT",
-    "version":"1453152401356000",
-    "ospath":"/home/rise/rvplayer/modules/local-storage/cache/dd6be87ae13b9d0a4c35420d1dfa1e37",
-    "osurl":"file:///home/rise/bucket/file.txt",
-    "through":"ws"
+    "from": "local-storage",
+    "topic": "FILE-UPDATE",
+    "filePath": "bucket/file.txt",
+    "status": "CURRENT",
+    "version": "1453152401356000",
+    "ospath": "/home/rise/rvplayer/modules/local-storage/cache/dd6be87ae13b9d0a4c35420d1dfa1e37",
+    "osurl": "file:///home/rise/bucket/file.txt",
+    "through": "ws"
   }
 
   var ERROR_MESSAGE = {
-    "from":"local-storage",
-    "topic":"FILE-ERROR",
-    "filePath":"bucket/file.txt",
-    "msg":"file transfer error",
-    "detail":"network failed"
+    "from": "local-storage",
+    "topic": "FILE-ERROR",
+    "filePath": "bucket/file.txt",
+    "msg": "file transfer error",
+    "detail": "network failed"
   };
 
   var _localMessaging, _messageHandler;

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -64,8 +64,24 @@ describe( "watchSingleFile", function() {
     });
   });
 
+  it( "should detect that a file is still not available", function( done ) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
+      expect( data.available ).to.be.false;
+
+      done();
+    });
+
+    expect( _messageHandler ).to.not.be.null;
+
+    _messageHandler( STALE_MESSAGE );
+  });
+
   it( "should detect when a watched file is available", function( done ) {
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
+      if ( !data.available ) {
+        return;
+      }
+
       expect( data ).to.deep.equal({
         available: true, fileUrl: "file:///home/rise/bucket/file.txt"
       });

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -102,7 +102,9 @@ describe( "watchSingleFile", function() {
       }
 
       expect( data ).to.deep.equal({
-        status: "CURRENT", fileUrl: "file:///home/rise/bucket/file.txt"
+        status: "CURRENT",
+        filePath: "bucket/file.txt",
+        fileUrl: "file:///home/rise/bucket/file.txt"
       });
 
       done();
@@ -137,6 +139,7 @@ describe( "watchSingleFile", function() {
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
       expect( data ).to.deep.equal({
         fileUrl: null,
+        filePath: "bucket/file.txt",
         status: "FILE-ERROR",
         errorMessage: "file transfer error",
         errorDetail: "network failed"

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -51,6 +51,9 @@ describe( "watchSingleFile", function() {
 
     RisePlayerConfiguration.LocalMessaging = {
       broadcastMessage: sinon.spy(),
+      isConnected: function() {
+        return true;
+      },
       receiveMessages: function( handler ) {
         _messageHandler = handler;
       }
@@ -60,6 +63,16 @@ describe( "watchSingleFile", function() {
   afterEach( function() {
     RisePlayerConfiguration.Helpers = _helpers;
     RisePlayerConfiguration.LocalMessaging = _localMessaging;
+  });
+
+  it( "should not broadcast a watch message if connection was lost", function() {
+    RisePlayerConfiguration.LocalMessaging.isConnected = function() {
+      return false;
+    };
+
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function() {});
+
+    expect( RisePlayerConfiguration.LocalMessaging.broadcastMessage ).to.not.have.been.called;
   });
 
   it( "should broadcast a watch message for a single file", function() {

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -1,0 +1,121 @@
+/* global describe, it, expect, afterEach, beforeEach, sinon */
+
+"use strict";
+
+describe( "watchSingleFile", function() {
+
+  var DELETED_MESSAGE = {
+    "from":"local-storage",
+    "topic":"FILE-UPDATE",
+    "filePath":"bucket/file.txt",
+    "status":"DELETED",
+    "through":"ws"
+  };
+
+  var STALE_MESSAGE = {
+    "from":"local-storage",
+    "topic":"FILE-UPDATE",
+    "filePath":"bucket/file.txt",
+    "status":"STALE",
+    "through":"ws"
+  };
+
+  var CURRENT_MESSAGE = {
+    "from":"local-storage",
+    "topic":"FILE-UPDATE",
+    "filePath":"bucket/file.txt",
+    "status":"CURRENT",
+    "version":"1453152401356000",
+    "ospath":"/home/rise/rvplayer/modules/local-storage/cache/dd6be87ae13b9d0a4c35420d1dfa1e37",
+    "osurl":"file:///home/rise/bucket/file.txt",
+    "through":"ws"
+  }
+
+  var ERROR_MESSAGE = {
+    "from":"local-storage",
+    "topic":"FILE-ERROR",
+    "filePath":"bucket/file.txt",
+    "msg":"file transfer error",
+    "detail":"network failed"
+  };
+
+  var _localMessaging, _messageHandler;
+
+  beforeEach( function() {
+    _localMessaging = RisePlayerConfiguration.LocalMessaging;
+
+    RisePlayerConfiguration.LocalMessaging = {
+      broadcastMessage: sinon.spy(),
+      onceClientsAreAvailable: function(modules, action) {
+        action();
+      },
+      receiveMessages: function(handler) {
+        _messageHandler = handler;
+      }
+    };
+  });
+
+  afterEach( function() {
+    RisePlayerConfiguration.LocalMessaging = _localMessaging;
+  });
+
+  it( "should broadcast a watch message for a single file", function() {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function() {});
+
+    expect( RisePlayerConfiguration.LocalMessaging.broadcastMessage ).to.have.been.calledWith({
+      topic: "watch", filePath: "bucket/file.txt"
+    });
+  });
+
+  it( "should detect when a watched file is available", function(done) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
+      expect(data).to.deep.equal({
+        available: true, fileUrl: "file:///home/rise/bucket/file.txt"
+      });
+
+      done();
+    });
+
+    expect( _messageHandler ).to.not.be.null;
+
+    _messageHandler(STALE_MESSAGE);
+    _messageHandler(CURRENT_MESSAGE);
+  });
+
+  it( "should detect when a watched file is deleted", function(done) {
+    var count = 0;
+    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
+      var available = count == 0;
+      expect(data.available).to.equal(available);
+
+      if( ! available ) {
+        done();
+      }
+
+      count++;
+    });
+
+    expect( _messageHandler ).to.not.be.null;
+
+    _messageHandler(CURRENT_MESSAGE);
+    _messageHandler(DELETED_MESSAGE);
+  });
+
+  it( "should detect a file error", function(done) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
+      expect(data).to.deep.equal({
+        available: false,
+        error: true,
+        errorMessage: "file transfer error",
+        errorDetail: "network failed"
+      });
+
+      done();
+    });
+
+    expect( _messageHandler ).to.not.be.null;
+
+    _messageHandler(ERROR_MESSAGE);
+  });
+
+});

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -5,51 +5,48 @@
 describe( "watchSingleFile", function() {
 
   var DELETED_MESSAGE = {
-    "from": "local-storage",
-    "topic": "FILE-UPDATE",
-    "filePath": "bucket/file.txt",
-    "status": "DELETED",
-    "through": "ws"
-  };
-
-  var STALE_MESSAGE = {
-    "from": "local-storage",
-    "topic": "FILE-UPDATE",
-    "filePath": "bucket/file.txt",
-    "status": "STALE",
-    "through": "ws"
-  };
-
-  var CURRENT_MESSAGE = {
-    "from": "local-storage",
-    "topic": "FILE-UPDATE",
-    "filePath": "bucket/file.txt",
-    "status": "CURRENT",
-    "version": "1453152401356000",
-    "ospath": "/home/rise/rvplayer/modules/local-storage/cache/dd6be87ae13b9d0a4c35420d1dfa1e37",
-    "osurl": "file:///home/rise/bucket/file.txt",
-    "through": "ws"
-  }
-
-  var ERROR_MESSAGE = {
-    "from": "local-storage",
-    "topic": "FILE-ERROR",
-    "filePath": "bucket/file.txt",
-    "msg": "file transfer error",
-    "detail": "network failed"
-  };
-
-  var _localMessaging, _messageHandler;
+      "from": "local-storage",
+      "topic": "FILE-UPDATE",
+      "filePath": "bucket/file.txt",
+      "status": "DELETED",
+      "through": "ws"
+    },
+    STALE_MESSAGE = {
+      "from": "local-storage",
+      "topic": "FILE-UPDATE",
+      "filePath": "bucket/file.txt",
+      "status": "STALE",
+      "through": "ws"
+    },
+    CURRENT_MESSAGE = {
+      "from": "local-storage",
+      "topic": "FILE-UPDATE",
+      "filePath": "bucket/file.txt",
+      "status": "CURRENT",
+      "version": "1453152401356000",
+      "ospath": "/home/rise/rvplayer/modules/local-storage/cache/dd6be87ae13b9d0a4c35420d1dfa1e37",
+      "osurl": "file:///home/rise/bucket/file.txt",
+      "through": "ws"
+    },
+    ERROR_MESSAGE = {
+      "from": "local-storage",
+      "topic": "FILE-ERROR",
+      "filePath": "bucket/file.txt",
+      "msg": "file transfer error",
+      "detail": "network failed"
+    },
+    _localMessaging,
+    _messageHandler;
 
   beforeEach( function() {
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
 
     RisePlayerConfiguration.LocalMessaging = {
       broadcastMessage: sinon.spy(),
-      onceClientsAreAvailable: function(modules, action) {
+      onceClientsAreAvailable: function( modules, action ) {
         action();
       },
-      receiveMessages: function(handler) {
+      receiveMessages: function( handler ) {
         _messageHandler = handler;
       }
     };
@@ -60,16 +57,16 @@ describe( "watchSingleFile", function() {
   });
 
   it( "should broadcast a watch message for a single file", function() {
-    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function() {});
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function() {});
 
     expect( RisePlayerConfiguration.LocalMessaging.broadcastMessage ).to.have.been.calledWith({
       topic: "watch", filePath: "bucket/file.txt"
     });
   });
 
-  it( "should detect when a watched file is available", function(done) {
-    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
-      expect(data).to.deep.equal({
+  it( "should detect when a watched file is available", function( done ) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
+      expect( data ).to.deep.equal({
         available: true, fileUrl: "file:///home/rise/bucket/file.txt"
       });
 
@@ -78,17 +75,19 @@ describe( "watchSingleFile", function() {
 
     expect( _messageHandler ).to.not.be.null;
 
-    _messageHandler(STALE_MESSAGE);
-    _messageHandler(CURRENT_MESSAGE);
+    _messageHandler( STALE_MESSAGE );
+    _messageHandler( CURRENT_MESSAGE );
   });
 
-  it( "should detect when a watched file is deleted", function(done) {
+  it( "should detect when a watched file is deleted", function( done ) {
     var count = 0;
-    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
-      var available = count == 0;
-      expect(data.available).to.equal(available);
 
-      if( ! available ) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
+      var available = count == 0;
+
+      expect( data.available ).to.equal( available );
+
+      if ( !available ) {
         done();
       }
 
@@ -97,13 +96,13 @@ describe( "watchSingleFile", function() {
 
     expect( _messageHandler ).to.not.be.null;
 
-    _messageHandler(CURRENT_MESSAGE);
-    _messageHandler(DELETED_MESSAGE);
+    _messageHandler( CURRENT_MESSAGE );
+    _messageHandler( DELETED_MESSAGE );
   });
 
-  it( "should detect a file error", function(done) {
-    RisePlayerConfiguration.LocalStorage.watchSingleFile('bucket/file.txt', function(data) {
-      expect(data).to.deep.equal({
+  it( "should detect a file error", function( done ) {
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
+      expect( data ).to.deep.equal({
         available: false,
         error: true,
         errorMessage: "file transfer error",
@@ -115,7 +114,7 @@ describe( "watchSingleFile", function() {
 
     expect( _messageHandler ).to.not.be.null;
 
-    _messageHandler(ERROR_MESSAGE);
+    _messageHandler( ERROR_MESSAGE );
   });
 
 });

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -35,17 +35,22 @@ describe( "watchSingleFile", function() {
       "msg": "file transfer error",
       "detail": "network failed"
     },
+    _helpers,
     _localMessaging,
     _messageHandler;
 
   beforeEach( function() {
+    _helpers = RisePlayerConfiguration.Helpers;
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
+
+    RisePlayerConfiguration.Helpers = {
+      onceClientsAreAvailable: function( modules, action ) {
+        action();
+      }
+    };
 
     RisePlayerConfiguration.LocalMessaging = {
       broadcastMessage: sinon.spy(),
-      onceClientsAreAvailable: function( modules, action ) {
-        action();
-      },
       receiveMessages: function( handler ) {
         _messageHandler = handler;
       }
@@ -53,6 +58,7 @@ describe( "watchSingleFile", function() {
   });
 
   afterEach( function() {
+    RisePlayerConfiguration.Helpers = _helpers;
     RisePlayerConfiguration.LocalMessaging = _localMessaging;
   });
 

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -72,7 +72,7 @@ describe( "watchSingleFile", function() {
 
   it( "should detect that a file is still not available", function( done ) {
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
-      expect( data.available ).to.be.false;
+      expect( data.status ).to.equal( "STALE" );
 
       done();
     });
@@ -84,12 +84,12 @@ describe( "watchSingleFile", function() {
 
   it( "should detect when a watched file is available", function( done ) {
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
-      if ( !data.available ) {
+      if ( !data.fileUrl ) {
         return;
       }
 
       expect( data ).to.deep.equal({
-        available: true, fileUrl: "file:///home/rise/bucket/file.txt"
+        status: "CURRENT", fileUrl: "file:///home/rise/bucket/file.txt"
       });
 
       done();
@@ -105,11 +105,9 @@ describe( "watchSingleFile", function() {
     var count = 0;
 
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
-      var available = count == 0;
+      expect( data.status ).to.equal( count ? "DELETED" : "CURRENT" );
 
-      expect( data.available ).to.equal( available );
-
-      if ( !available ) {
+      if ( !data.fileUrl ) {
         done();
       }
 
@@ -125,8 +123,8 @@ describe( "watchSingleFile", function() {
   it( "should detect a file error", function( done ) {
     RisePlayerConfiguration.LocalStorage.watchSingleFile( "bucket/file.txt", function( data ) {
       expect( data ).to.deep.equal({
-        available: false,
-        error: true,
+        fileUrl: null,
+        status: "FILE-ERROR",
         errorMessage: "file transfer error",
         errorDetail: "network failed"
       });


### PR DESCRIPTION
Common functionality for file watch:
- in local messaging, a public method *onceClientsAreAvailable* was added to invoke an action after a module is present on player-electron; chrome does not need this.
- a list of clients is stored to support this method.
- the player type is now stored to distinguish between Electron and ChromeOS; the connection type was not used for this because in the future 'window' may be used by Electron instead of a web socket.
- A new local storage object was created with a function to listen to single files and notify changes on availability and errors to a callback.

rise-data-image uses this functionality ( see other PR ).

This was tested manually on a local page loaded on electron player.
