### PR TITLE
Feature/start load process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
       "error",
       "double"
     ],
+    "func-names": "off",
     "newline-after-var": [
       "error",
       "always"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@
 
   gulp.task( "scripts", () => {
     return gulp.src([
+      "src/rise-component-loader.js",
       "src/rise-helpers.js",
       "src/rise-local-messaging.js",
       "src/rise-local-storage.js",
@@ -48,6 +49,7 @@
       "dist/rise-local-messaging.js",
       "dist/rise-helpers.js",
       "dist/rise-local-storage.js",
+      "dist/rise-component-loader.js",
       "test/unit/*test.js" ] }
   ));
 

--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -2,6 +2,32 @@
 
 RisePlayerConfiguration.ComponentLoader = (() => {
 
+  let _rolloutEnvironment;
+
+  _determineRolloutEnvironment() {
+    const playerInfo = RisePlayerConfiguration.getPlayerInfo();
+
+    if ( playerInfo.developmentManifestUrl ) {
+      _rolloutEnvironment = "development";
+    }
+    else {
+      _rolloutEnvironment = playerInfo.playerType;
+
+      if( !_rolloutEnvironment ) {
+        console.log( `No playerType parameter provided.` );
+
+        return false;
+      }
+      if( _rolloutEnvironment !== "beta" && _rolloutEnvironment !== "stable" ) {
+        console.log( `Illegal playerType parameter provided: '${ _rolloutEnvironment }'` );
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   function connectionHandler( event ) {
     if (connected) {
       window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
@@ -10,12 +36,21 @@ RisePlayerConfiguration.ComponentLoader = (() => {
     }
   }
 
+  function getRolloutEnvironment() {
+    return _rolloutEnvironment;
+  }
+
   function load() {
-    console.log( "loading" );
+    if ( !_determineRolloutEnvironment() ) {
+      return;
+    }
+
+    // TODO: load the page
   }
 
   return {
     connectionHandler: connectionHandler,
+    getRolloutEnvironment: getRolloutEnvironment,
     load: load
   }
 

--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -21,7 +21,7 @@ RisePlayerConfiguration.ComponentLoader = (() => {
 
 })();
 
-if ( !RisePlayerConfiguration.isTestEnvironment() ) {
+if ( !RisePlayerConfiguration.Helpers.isTestEnvironment() ) {
   const handler = RisePlayerConfiguration.ComponentLoader.connectionHandler;
 
   window.addEventListener( "rise-local-messaging-connection", handler);

--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-console */
+
+RisePlayerConfiguration.ComponentLoader = (() => {
+
+  function connectionHandler( event ) {
+    if (connected) {
+      window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
+
+      load();
+    }
+  }
+
+  function load() {
+    console.log( "loading" );
+  }
+
+  return {
+    connectionHandler: connectionHandler,
+    load: load
+  }
+
+})();
+
+if ( !RisePlayerConfiguration.isTestEnvironment() ) {
+  const handler = RisePlayerConfiguration.ComponentLoader.connectionHandler;
+
+  window.addEventListener( "rise-local-messaging-connection", handler);
+}

--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -4,21 +4,20 @@ RisePlayerConfiguration.ComponentLoader = (() => {
 
   let _rolloutEnvironment;
 
-  _determineRolloutEnvironment() {
+  function _determineRolloutEnvironment() {
     const playerInfo = RisePlayerConfiguration.getPlayerInfo();
 
     if ( playerInfo.developmentManifestUrl ) {
       _rolloutEnvironment = "development";
-    }
-    else {
+    } else {
       _rolloutEnvironment = playerInfo.playerType;
 
-      if( !_rolloutEnvironment ) {
-        console.log( `No playerType parameter provided.` );
+      if ( !_rolloutEnvironment ) {
+        console.log( "No playerType parameter provided." );
 
         return false;
       }
-      if( _rolloutEnvironment !== "beta" && _rolloutEnvironment !== "stable" ) {
+      if ( _rolloutEnvironment !== "beta" && _rolloutEnvironment !== "stable" ) {
         console.log( `Illegal playerType parameter provided: '${ _rolloutEnvironment }'` );
 
         return false;
@@ -29,7 +28,7 @@ RisePlayerConfiguration.ComponentLoader = (() => {
   }
 
   function connectionHandler( event ) {
-    if (connected) {
+    if ( event.detail.isConnected ) {
       window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
 
       load();
@@ -41,7 +40,7 @@ RisePlayerConfiguration.ComponentLoader = (() => {
   }
 
   function load() {
-    if ( !_determineRolloutEnvironment() ) {
+    if ( !_determineRolloutEnvironment()) {
       return;
     }
 
@@ -56,8 +55,8 @@ RisePlayerConfiguration.ComponentLoader = (() => {
 
 })();
 
-if ( !RisePlayerConfiguration.Helpers.isTestEnvironment() ) {
+if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
   const handler = RisePlayerConfiguration.ComponentLoader.connectionHandler;
 
-  window.addEventListener( "rise-local-messaging-connection", handler);
+  window.addEventListener( "rise-local-messaging-connection", handler );
 }

--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -2,7 +2,7 @@
 
 RisePlayerConfiguration.ComponentLoader = (() => {
 
-  let _rolloutEnvironment;
+  let _rolloutEnvironment = null;
 
   function _determineRolloutEnvironment() {
     const playerInfo = RisePlayerConfiguration.getPlayerInfo();
@@ -10,18 +10,18 @@ RisePlayerConfiguration.ComponentLoader = (() => {
     if ( playerInfo.developmentManifestUrl ) {
       _rolloutEnvironment = "development";
     } else {
-      _rolloutEnvironment = playerInfo.playerType;
-
-      if ( !_rolloutEnvironment ) {
+      if ( !playerInfo.playerType ) {
         console.log( "No playerType parameter provided." );
 
         return false;
       }
-      if ( _rolloutEnvironment !== "beta" && _rolloutEnvironment !== "stable" ) {
-        console.log( `Illegal playerType parameter provided: '${ _rolloutEnvironment }'` );
+      if ( playerInfo.playerType !== "beta" && playerInfo.playerType !== "stable" ) {
+        console.log( `Illegal playerType parameter provided: '${ playerInfo.playerType }'` );
 
         return false;
       }
+
+      _rolloutEnvironment = playerInfo.playerType;
     }
 
     return true;
@@ -44,10 +44,17 @@ RisePlayerConfiguration.ComponentLoader = (() => {
       return;
     }
 
+    console.log( "loading" );
     // TODO: load the page
   }
 
+  // for testing purposes
+  function clear() {
+    _rolloutEnvironment = null;
+  }
+
   return {
+    clear: clear,
     connectionHandler: connectionHandler,
     getRolloutEnvironment: getRolloutEnvironment,
     load: load

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -8,6 +8,10 @@ RisePlayerConfiguration.Helpers = (() => {
     return names.every( name => _clients.indexOf( name ) >= 0 );
   }
 
+  function isTestEnvironment() {
+    return window.env && window.env.RISE_ENV && window.env.RISE_ENV === "test";
+  }
+
   function onceClientsAreAvailable( requiredClientNames, action ) {
     let invoked = false;
     const names = typeof requiredClientNames === "string" ?
@@ -41,6 +45,7 @@ RisePlayerConfiguration.Helpers = (() => {
   }
 
   return {
+    isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable,
     reset: reset
   }

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -141,7 +141,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function _resetForAutomatedTests() {
-    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment() ) {
+    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
       return;
     }
 

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -141,7 +141,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function _resetForAutomatedTests() {
-    if ( !RisePlayerConfiguration.isTestEnvironment() ) {
+    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment() ) {
       return;
     }
 

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -140,7 +140,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function _resetForAutomatedTests() {
-    if ( !window.env || !window.env.RISE_ENV || window.env.RISE_ENV !== "test" ) {
+    if ( !RisePlayerConfiguration.isTestEnvironment() ) {
       return;
     }
 

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -11,11 +11,11 @@ const RisePlayerConfiguration = {
     if ( !RisePlayerConfiguration.LocalMessaging ) {
       throw new Error( "RiseLocalMessaging script was not loaded" );
     }
-    if ( !RisePlayerConfiguration.Helpers ) {
-      throw new Error( "RiseHelpers script was not loaded" );
-    }
     if ( !RisePlayerConfiguration.LocalStorage ) {
       throw new Error( "RiseLocalStorage script was not loaded" );
+    }
+    if ( !RisePlayerConfiguration.Helpers ) {
+      throw new Error( "RiseHelpers script was not loaded" );
     }
 
     RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -2,8 +2,17 @@ const RisePlayerConfiguration = {
   ComponentLoader: null,
   configure: ( playerInfo, localMessagingInfo ) => {
 
+    if ( !RisePlayerConfiguration.ComponentLoader ) {
+      throw new Error( "RiseComponentLoader script was not loaded" );
+    }
+
+    RisePlayerConfiguration.getPlayerInfo = () => playerInfo;
+
     if ( !RisePlayerConfiguration.LocalMessaging ) {
       throw new Error( "RiseLocalMessaging script was not loaded" );
+    }
+    if ( !RisePlayerConfiguration.LocalStorage ) {
+      throw new Error( "RiseLocalStorage script was not loaded" );
     }
 
     RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
@@ -13,6 +22,10 @@ const RisePlayerConfiguration = {
     // lock down RisePlayerConfiguration object
     Object.freeze( RisePlayerConfiguration );
   },
+  isTestEnvironment: () => {
+    return window.env && window.env.RISE_ENV && window.env.RISE_ENV === "test";
+  },
   LocalMessaging: null,
+  LocalStorage: null,
   Logger: null
 };

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -23,7 +23,9 @@ const RisePlayerConfiguration = {
     //TODO: other processing
 
     // lock down RisePlayerConfiguration object
-    Object.freeze( RisePlayerConfiguration );
+    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+      Object.freeze( RisePlayerConfiguration );
+    }
   },
   Helpers: null,
   LocalMessaging: null,

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -1,23 +1,20 @@
 
-/* global describe, it, expect, afterEach, beforeEach, sinon */
+/* global describe, it, expect */
 
 "use strict";
 
 describe( "ComponentLoader", function() {
 
-  afterEach( function() {
-    delete top.postToPlayer;
-    delete top.receiveFromPlayer;
-  });
+  var rolloutEnvironment;
 
-  it( "should always invoke the action in ChromeOS player", function() {
-    var spy = sinon.spy();
+  it( "should recoginize the rollout environment as beta", function() {
+    RisePlayerConfiguration.configure({ playerType: "beta" }, {});
 
-    RisePlayerConfiguration.configure({ playerType: "beta" });
+    RisePlayerConfiguration.ComponentLoader.load();
 
-    RisePlayerConfiguration.ComponentLoader.onceClientsAreAvailable( "local-storage", spy );
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
 
-    expect( spy ).to.have.been.called;
+    expect( rolloutEnvironment ).to.equal( "beta" );
   });
 
 });

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -6,6 +6,12 @@ describe( "ComponentLoader", function() {
 
   var rolloutEnvironment;
 
+  function createConnectionEvent( isConnected ) {
+    return new CustomEvent( "rise-local-messaging-connection", {
+      detail: { isConnected: isConnected }
+    })
+  }
+
   afterEach( function() {
     RisePlayerConfiguration.ComponentLoader.clear();
   });
@@ -59,6 +65,43 @@ describe( "ComponentLoader", function() {
 
     rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
 
+    expect( rolloutEnvironment ).to.be.null;
+  });
+
+  it( "should attempt to load the components only once", function() {
+    var connectionEvent = createConnectionEvent( true ),
+      disconnectionEvent = createConnectionEvent( false );
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+    expect( rolloutEnvironment ).to.be.null;
+
+    // register the listener as runtime would do
+    window.addEventListener( "rise-local-messaging-connection", RisePlayerConfiguration.ComponentLoader.connectionHandler );
+
+    RisePlayerConfiguration.configure({ playerType: "beta" }, {});
+
+    // it shouldn't attempt to load if not connected
+    window.dispatchEvent( disconnectionEvent );
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+    expect( rolloutEnvironment ).to.be.null;
+
+    // simulate connection
+    window.dispatchEvent( connectionEvent );
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+    expect( rolloutEnvironment ).to.equal( "beta" );
+
+    // clear state, so we can see if it's initialized again later
+    RisePlayerConfiguration.ComponentLoader.clear();
+
+    connectionEvent = new CustomEvent( "rise-local-messaging-connection", {
+      detail: { isConnected: true }
+    });
+    window.dispatchEvent( connectionEvent );
+
+    // the component load is not attempted again.
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
     expect( rolloutEnvironment ).to.be.null;
   });
 

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -1,5 +1,4 @@
-
-/* global describe, it, expect */
+/* global describe, it, expect, afterEach */
 
 "use strict";
 
@@ -7,7 +6,11 @@ describe( "ComponentLoader", function() {
 
   var rolloutEnvironment;
 
-  it( "should recoginize the rollout environment as beta", function() {
+  afterEach( function() {
+    RisePlayerConfiguration.ComponentLoader.clear();
+  });
+
+  it( "should recognize the rollout environment as beta", function() {
     RisePlayerConfiguration.configure({ playerType: "beta" }, {});
 
     RisePlayerConfiguration.ComponentLoader.load();
@@ -15,6 +18,38 @@ describe( "ComponentLoader", function() {
     rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
 
     expect( rolloutEnvironment ).to.equal( "beta" );
+  });
+
+  it( "should recognize the rollout environment as stable", function() {
+    RisePlayerConfiguration.configure({ playerType: "stable" }, {});
+
+    RisePlayerConfiguration.ComponentLoader.load();
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+
+    expect( rolloutEnvironment ).to.equal( "stable" );
+  });
+
+  it( "should assume a development rollout environment if developmentManifestUrl is provided", function() {
+    RisePlayerConfiguration.configure({
+      developmentManifestUrl: "http://localhost:9000/manifest.json"
+    }, {});
+
+    RisePlayerConfiguration.ComponentLoader.load();
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+
+    expect( rolloutEnvironment ).to.equal( "development" );
+  });
+
+  it( "should not set the rollout environment if an invalid player type is provided", function() {
+    RisePlayerConfiguration.configure({ playerType: "other" }, {});
+
+    RisePlayerConfiguration.ComponentLoader.load();
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+
+    expect( rolloutEnvironment ).to.be.null;
   });
 
 });

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -52,4 +52,14 @@ describe( "ComponentLoader", function() {
     expect( rolloutEnvironment ).to.be.null;
   });
 
+  it( "should not set the rollout environment if no player type is provided", function() {
+    RisePlayerConfiguration.configure({}, {});
+
+    RisePlayerConfiguration.ComponentLoader.load();
+
+    rolloutEnvironment = RisePlayerConfiguration.ComponentLoader.getRolloutEnvironment();
+
+    expect( rolloutEnvironment ).to.be.null;
+  });
+
 });

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -1,0 +1,23 @@
+
+/* global describe, it, expect, afterEach, beforeEach, sinon */
+
+"use strict";
+
+describe( "ComponentLoader", function() {
+
+  afterEach( function() {
+    delete top.postToPlayer;
+    delete top.receiveFromPlayer;
+  });
+
+  it( "should always invoke the action in ChromeOS player", function() {
+    var spy = sinon.spy();
+
+    RisePlayerConfiguration.configure({ playerType: "beta" });
+
+    RisePlayerConfiguration.ComponentLoader.onceClientsAreAvailable( "local-storage", spy );
+
+    expect( spy ).to.have.been.called;
+  });
+
+});

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -35,13 +35,15 @@ describe( "watchSingleFile", function() {
       "msg": "file transfer error",
       "detail": "network failed"
     },
-    _helpers,
-    _localMessaging,
+    _configuration,
     _messageHandler;
 
   beforeEach( function() {
-    _helpers = RisePlayerConfiguration.Helpers;
-    _localMessaging = RisePlayerConfiguration.LocalMessaging;
+    _configuration = RisePlayerConfiguration;
+
+    RisePlayerConfiguration = {
+      LocalStorage: RisePlayerConfiguration.LocalStorage
+    };
 
     RisePlayerConfiguration.Helpers = {
       onceClientsAreAvailable: function( modules, action ) {
@@ -61,8 +63,7 @@ describe( "watchSingleFile", function() {
   });
 
   afterEach( function() {
-    RisePlayerConfiguration.Helpers = _helpers;
-    RisePlayerConfiguration.LocalMessaging = _localMessaging;
+    RisePlayerConfiguration = _configuration;
   });
 
   it( "should not broadcast a watch message if connection was lost", function() {

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -35,11 +35,13 @@ describe( "watchSingleFile", function() {
       "msg": "file transfer error",
       "detail": "network failed"
     },
-    _configuration,
+    _helpers,
+    _localMessaging,
     _messageHandler;
 
   beforeEach( function() {
-    _configuration = RisePlayerConfiguration;
+    _helpers = RisePlayerConfiguration.Helpers;
+    _localMessaging = RisePlayerConfiguration.LocalMessaging;
 
     RisePlayerConfiguration = {
       LocalStorage: RisePlayerConfiguration.LocalStorage
@@ -63,7 +65,8 @@ describe( "watchSingleFile", function() {
   });
 
   afterEach( function() {
-    RisePlayerConfiguration = _configuration;
+    RisePlayerConfiguration.Helpers = _helpers;
+    RisePlayerConfiguration.LocalMessaging = _localMessaging;
   });
 
   it( "should not broadcast a watch message if connection was lost", function() {

--- a/test/unit/rise-local-storage.test.js
+++ b/test/unit/rise-local-storage.test.js
@@ -43,10 +43,6 @@ describe( "watchSingleFile", function() {
     _helpers = RisePlayerConfiguration.Helpers;
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
 
-    RisePlayerConfiguration = {
-      LocalStorage: RisePlayerConfiguration.LocalStorage
-    };
-
     RisePlayerConfiguration.Helpers = {
       onceClientsAreAvailable: function( modules, action ) {
         action();


### PR DESCRIPTION
This implements the steps 1 & 3 of the load process.

- Added a component-loader script, and included in build and tests.
- Registered the connection event with the loader, so it starts loading once connected.
- Unregistered the previous event once it's called the first time, to avoid multiple loading.
- Exposed the player data in the configuration object, so the component-loader can see it.
- Determine the rollout environment from the player data
- Created unit tests for the steps above.
- Extracted the check for test environment to the Helpers object, so it's reused from different places.
- Called Object.freeze for the configuration object only when not on a test environment; because some tests modify and then restore the object to facilitate testing, and freeze was causing some trouble there.
- Disabled func-names eslint directive, as it is generating tons of noise in the test output script.

I manually tested all of this, I'm creating another PR for the modified POC.