### PR TITLE
allow component URLs overriding

### DIFF
--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -72,7 +72,7 @@ RisePlayerConfiguration.ComponentLoader = (() => {
     // TODO: all rollout procedure
 
     // fixed component names for the time being
-    const components = [
+    const components = RisePlayerConfiguration.ComponentLoader.components || [
       {
         name: "rise-data-image",
         url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"


### PR DESCRIPTION
This is a quick way to allow components overriding, 

It may also help with making easier to test new components without modifying the launcher until the new rollout design is completed and implemented.

This is used in the new changes to the e2e PR, specifically here:
https://github.com/Rise-Vision/rise-data-image/blob/chore/e2e_test/e2e/rise-data-image.html#L23
