### PR TITLE
extract configuration scripts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,8 @@
 
   gulp.task( "scripts", () => {
     return gulp.src([
+      "src/config/config-prod.js",
+      "src/config/config-test.js",
       "src/rise-component-loader.js",
       "src/rise-helpers.js",
       "src/rise-local-messaging.js",
@@ -49,6 +51,7 @@
       "node_modules/promise-polyfill/dist/polyfill.min.js",
       "node_modules/whatwg-fetch/dist/fetch.umd.js",
       "node_modules/dom4/build/dom4.js",
+      "dist/config-test.js",
       "dist/rise-player-configuration.js",
       "dist/rise-local-messaging.js",
       "dist/rise-helpers.js",
@@ -64,6 +67,7 @@
       "node_modules/promise-polyfill/dist/polyfill.min.js",
       "node_modules/whatwg-fetch/dist/fetch.umd.js",
       "node_modules/dom4/build/dom4.js",
+      "dist/config-test.js",
       "dist/rise-player-configuration.js",
       "dist/rise-local-messaging.js",
       "dist/rise-helpers.js",

--- a/src/config/config-prod.js
+++ b/src/config/config-prod.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-unused-vars */
+
+const TEMPLATE_COMMON_CONFIG = {
+  LOGGER_CLIENT_ID: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
+  LOGGER_CLIENT_SECRET: "nlZyrcPLg6oEwO9f9Wfn29Wh",
+  LOGGER_REFRESH_TOKEN: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",
+  LOGGER_PROJECT: "client-side-events",
+  LOGGER_DATASET: "Display_Events",
+  LOGGER_TABLE: "events"
+};

--- a/src/config/config-test.js
+++ b/src/config/config-test.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-unused-vars */
+
+const TEMPLATE_COMMON_CONFIG = {
+  LOGGER_CLIENT_ID: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
+  LOGGER_CLIENT_SECRET: "nlZyrcPLg6oEwO9f9Wfn29Wh",
+  LOGGER_REFRESH_TOKEN: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",
+  LOGGER_PROJECT: "client-side-events",
+  LOGGER_DATASET: "Display_Events",
+  LOGGER_TABLE: "events_test"
+};

--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -1,14 +1,5 @@
+/* global TEMPLATE_COMMON_CONFIG */
 /* eslint-disable no-console, one-var */
-
-// TODO: extract to config file
-const TEMPLATE_COMMON_CONFIG = {
-  LOGGER_CLIENT_ID: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
-  LOGGER_CLIENT_SECRET: "nlZyrcPLg6oEwO9f9Wfn29Wh",
-  LOGGER_REFRESH_TOKEN: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",
-  LOGGER_PROJECT: "client-side-events",
-  LOGGER_DATASET: "Display_Events",
-  LOGGER_TABLE: "events_test"
-};
 
 RisePlayerConfiguration.Logger = (() => {
 


### PR DESCRIPTION
I extracted configuration into test and prod. If more levels ( dev ? ) are needed later, they can be easily created from here. Currently the only difference between environments is the table where rows are being logged to.
