### PR TITLE
adopt display id from configuration

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -26,8 +26,6 @@ const RisePlayerConfiguration = {
     RisePlayerConfiguration.Logger.configure();
     RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
 
-    //TODO: other processing
-
     // lock down RisePlayerConfiguration object
     if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
       Object.freeze( RisePlayerConfiguration );
@@ -45,12 +43,14 @@ const RisePlayerConfiguration = {
     return match ? match[ 2 ] : null;
   },
   getCompanyId: function() {
-    // TODO: still not decided where this will come from.
-    return "COMPANY_ID";
+    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+
+    return playerInfo ? playerInfo.companyId : null;
   },
   getDisplayId: function() {
-    // TODO: still not decided where this will come from.
-    return "DISPLAY_ID";
+    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+
+    return playerInfo ? playerInfo.displayId : null;
   },
   Helpers: null,
   LocalMessaging: null,

--- a/test/integration/rise-components-loader.test.js
+++ b/test/integration/rise-components-loader.test.js
@@ -25,6 +25,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"

--- a/test/unit/rise-components-loader.test.js
+++ b/test/unit/rise-components-loader.test.js
@@ -20,6 +20,8 @@ describe( "ComponentLoader", function() {
 
     it( "should recognize the rollout environment as beta", function() {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -34,6 +36,8 @@ describe( "ComponentLoader", function() {
 
     it( "should recognize the rollout environment as stable", function() {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "stable",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -48,6 +52,8 @@ describe( "ComponentLoader", function() {
 
     it( "should assume a development rollout environment if developmentManifestUrl is provided", function() {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         developmentManifestUrl: "http://localhost:9000/manifest.json"
       }, {});
 
@@ -68,7 +74,11 @@ describe( "ComponentLoader", function() {
 
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
-      RisePlayerConfiguration.configure({ playerType: "other" }, {});
+      RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
+        playerType: "other"
+      }, {});
 
       RisePlayerConfiguration.ComponentLoader.load();
 
@@ -87,7 +97,10 @@ describe( "ComponentLoader", function() {
 
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
-      RisePlayerConfiguration.configure({}, {});
+      RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID"
+      }, {});
 
       RisePlayerConfiguration.ComponentLoader.load();
 
@@ -107,6 +120,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-local-messaging-connection", RisePlayerConfiguration.ComponentLoader.connectionHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -152,6 +167,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -179,6 +196,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -209,6 +228,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -259,6 +280,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"
@@ -303,6 +326,8 @@ describe( "ComponentLoader", function() {
       window.addEventListener( "rise-components-loaded", componentsLoadedHandler );
 
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "1.1.1.1.0",
         os: "Windows"

--- a/test/unit/rise-logger/big-query.test.js
+++ b/test/unit/rise-logger/big-query.test.js
@@ -202,6 +202,8 @@ describe( "Big Query logging", function() {
 
         beforeEach( function() {
           RisePlayerConfiguration.configure({
+            displayId: "DISPLAY_ID",
+            companyId: "COMPANY_ID",
             playerType: "beta",
             os: "Ubuntu 64",
             playerVersion: "2018.01.14.10.00",
@@ -548,6 +550,8 @@ describe( "Big Query logging", function() {
 
       it( "should disable BiqQuery logging on developer mode", function() {
         RisePlayerConfiguration.configure({
+          displayId: "DISPLAY_ID",
+          companyId: "COMPANY_ID",
           playerType: "developer",
           os: "Ubuntu 64",
           playerVersion: "2018.01.01.10.00",
@@ -566,6 +570,8 @@ describe( "Big Query logging", function() {
 
       it( "should log debug entries if debug mode was enabled", function() {
         RisePlayerConfiguration.configure({
+          displayId: "DISPLAY_ID",
+          companyId: "COMPANY_ID",
           playerType: "beta",
           os: "Ubuntu 64",
           playerVersion: "2018.01.01.10.00",
@@ -586,6 +592,8 @@ describe( "Big Query logging", function() {
 
       it( "should log a debug event with the debug method if debug was enabled", function() {
         RisePlayerConfiguration.configure({
+          displayId: "DISPLAY_ID",
+          companyId: "COMPANY_ID",
           playerType: "beta",
           os: "Ubuntu 64",
           playerVersion: "2018.01.01.10.00",

--- a/test/unit/rise-logger/configuration.test.js
+++ b/test/unit/rise-logger/configuration.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable one-var, vars-on-top */
-/* global describe, it, expect, afterEach, sinon */
+/* global describe, it, expect, afterEach */
 
 "use strict";
 
@@ -23,6 +23,8 @@ describe( "configure", function() {
 
   it( "should configure logging during beta stage", function() {
     RisePlayerConfiguration.configure({
+      displayId: "DISPLAY_ID",
+      companyId: "COMPANY_ID",
       playerType: "beta",
       os: "Ubuntu 64",
       playerVersion: "2018.01.01.10.00"
@@ -46,6 +48,8 @@ describe( "configure", function() {
 
   it( "should configure logging during stable stage", function() {
     RisePlayerConfiguration.configure({
+      displayId: "DISPLAY_ID",
+      companyId: "COMPANY_ID",
       playerType: "stable",
       os: "Ubuntu 64",
       playerVersion: "2018.01.01.10.00"
@@ -69,6 +73,8 @@ describe( "configure", function() {
 
   it( "should recognize player ip and chrome version if they are provided", function() {
     RisePlayerConfiguration.configure({
+      displayId: "DISPLAY_ID",
+      companyId: "COMPANY_ID",
       playerType: "beta",
       os: "Ubuntu 64",
       playerVersion: "2018.01.01.10.00",
@@ -94,6 +100,8 @@ describe( "configure", function() {
   it( "should fail if player version is not provided", function() {
     try {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         os: "Ubuntu 64"
       }, {});
@@ -107,6 +115,8 @@ describe( "configure", function() {
   it( "should fail if operating system is not provided", function() {
     try {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "2018.01.01.10.00"
       }, {});
@@ -118,11 +128,9 @@ describe( "configure", function() {
   });
 
   it( "should fail if display id is not provided", function() {
-    var stub = sinon.stub( RisePlayerConfiguration, "getDisplayId" )
-      .returns( undefined );
-
     try {
       RisePlayerConfiguration.configure({
+        companyId: "COMPANY_ID",
         playerType: "beta",
         playerVersion: "2018.01.01.10.00",
         os: "Ubuntu 64"
@@ -131,17 +139,13 @@ describe( "configure", function() {
       expect.fail();
     } catch ( error ) {
       expect( error.message ).to.equal( "No display id was provided" );
-    } finally {
-      stub.restore();
     }
   });
 
   it( "should fail if company id is not provided", function() {
-    var stub = sinon.stub( RisePlayerConfiguration, "getCompanyId" )
-      .returns( undefined );
-
     try {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
         playerType: "beta",
         playerVersion: "2018.01.01.10.00",
         os: "Ubuntu 64"
@@ -150,14 +154,14 @@ describe( "configure", function() {
       expect.fail();
     } catch ( error ) {
       expect( error.message ).to.equal( "No company id was provided" );
-    } finally {
-      stub.restore();
     }
   });
 
   it( "should enable debug logs", function() {
     RisePlayerConfiguration.configure({
       debug: true,
+      displayId: "DISPLAY_ID",
+      companyId: "COMPANY_ID",
       playerType: "stable",
       os: "Ubuntu 64",
       playerVersion: "2018.01.01.10.00"
@@ -170,6 +174,8 @@ describe( "configure", function() {
   it( "should explicitly disable debug logs", function() {
     RisePlayerConfiguration.configure({
       debug: false,
+      displayId: "DISPLAY_ID",
+      companyId: "COMPANY_ID",
       playerType: "stable",
       os: "Ubuntu 64",
       playerVersion: "2018.01.01.10.00"

--- a/test/unit/rise-logger/log-entry.test.js
+++ b/test/unit/rise-logger/log-entry.test.js
@@ -21,6 +21,8 @@ describe( "log-entry", function() {
 
     beforeEach( function() {
       RisePlayerConfiguration.configure({
+        displayId: "DISPLAY_ID",
+        companyId: "COMPANY_ID",
         playerType: "beta",
         os: "Ubuntu 64",
         playerVersion: "2018.01.01.10.00",


### PR DESCRIPTION
The display id is now read from configuration.

A bunch of tests now include that configuration. Demo pages and e2e pages will also require to incorporate this change.
