### PR TITLE
Chore/remove rise data image

### DIFF
--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -74,10 +74,6 @@ RisePlayerConfiguration.ComponentLoader = (() => {
     // fixed component names for the time being
     const components = RisePlayerConfiguration.ComponentLoader.components || [
       {
-        name: "rise-data-image",
-        url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"
-      },
-      {
         name: "rise-data-financial",
         url: "https://widgets.risevision.com/beta/components/rise-data-financial/rise-data-financial.js"
       }

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -44,10 +44,15 @@ RisePlayerConfiguration.Helpers = (() => {
     _clients = [];
   }
 
-  return {
+  const exposedFunctions = {
     isTestEnvironment: isTestEnvironment,
-    onceClientsAreAvailable: onceClientsAreAvailable,
-    reset: reset
+    onceClientsAreAvailable: onceClientsAreAvailable
+  };
+
+  if ( isTestEnvironment()) {
+    exposedFunctions.reset = reset
   }
+
+  return exposedFunctions;
 
 })();


### PR DESCRIPTION
This removes rise-data-image from loader.

I also removed reset from the exposed production functions of helpers, but did not add more functionality to helpers object for the time being.
