### PR TITLE
Chore/run e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,15 +57,17 @@ jobs:
       - run: |
           VERSION=$(cat version-string/version)
           sed "
+            s!__STAGE__/common!<< parameters.stage >>/common/$VERSION!;
             s/__STAGE__/<< parameters.stage >>/;
-            s/__VERSION__/$VERSION/;
+            s!staging/components/rise-data-image/__VERSION__!<< parameters.stage >>/components/rise-data-image!;
             s/__PLAYER__/electron/;
             s/__CONNECTION__/websocket/;
           " rise-data-image/e2e/rise-data-image.html > rise-data-image/e2e/rise-data-image-electron.html
       - run: cp rise-data-image/e2e/polymer-e2e-electron.json rise-data-image/polymer.json
-      - run: cat rise-data-image/polymer.json
+      - run: cat rise-data-image/e2e/rise-data-image-electron.html
       - run: |
           cd rise-data-image
+          npm install
           polymer build
       - persist_to_workspace:
           root: ./rise-data-image/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
   gcloud-setup:
     docker: &GCSIMAGE
       - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+        environment:
+          GS_BASE: gs://widgets.risevision.com
     steps:
       - run: mkdir -p ~/.ssh
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
@@ -92,13 +94,62 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          GS_BASE=gs://widgets.risevision.com
           VERSION=$(cat version-string/version)
           TARGET=$GS_BASE/staging/common/$VERSION/
           echo Deploying version $VERSION to common
           gsutil cp dist/*.js $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
+
+  deploy-e2e-page:
+    parameters:
+      stage:
+        type: string
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: |
+          TARGET=$GS_BASE/<< parameters.stage >>/e2e/rise-data-image/electron
+          echo Deploying << parameters.stage >> electron e2e page for rise-data-image
+          gsutil rsync -d -r base $TARGET
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+          gsutil acl -r ch -u AllUsers:R $TARGET
+
+  test-e2e-electron:
+    parameters:
+      stage:
+        type: string
+      displayId:
+        type: string
+    docker: &E2EIMAGE
+      - image: jenkinsrise/jenkinsrise-cci-image-launcher-electron-e2e:0.0.2
+        environment:
+          SCREENSHOTS_BASE: https://storage.googleapis.com/risevision-display-screenshots
+          PLAYER_CONFIG: /home/circleci/rvplayer/RiseDisplayNetworkII.ini
+    steps:
+      - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
+      - run: |
+          cd rise-launcher-electron-e2e
+          npm install
+      - run: mkdir ~/rvplayer
+      - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
+      - run: echo proxy= >> $PLAYER_CONFIG
+      - run:
+          name: run the test
+          command: |
+            EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
+            cd rise-launcher-electron-e2e
+            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20 << parameters.stage >>
+      - run: mkdir output
+      - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
+      - store_artifacts:
+          path: output
 
   deploy-production:
     parameters:
@@ -114,7 +165,6 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          GS_BASE=gs://widgets.risevision.com
           TARGET=$GS_BASE/<< parameters.stage >>/common
           gsutil cp dist/*.js $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
@@ -165,8 +215,8 @@ workflows:
           filters:
             branches:
               only:
-                - /^(stage|staging)[/].*/
                 - master
+                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -177,10 +227,54 @@ workflows:
             branches:
               only:
                 - build/stable
+      - deploy-e2e-page:
+          stage: beta
+          name: deploy-e2e-page-beta
+          requires:
+            - gcloud-setup
+            - build-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - deploy-e2e-page:
+          stage: stable
+          name: deploy-e2e-page-stable
+          requires:
+            - gcloud-setup
+            - build-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
+      - test-e2e-electron:
+          stage: beta
+          displayId: 9YP68DHZ4HUJ
+          name: test-e2e-electron-beta
+          requires:
+            - deploy-stage
+            - deploy-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - test-e2e-electron:
+          stage: stable
+          displayId: U2SQ87Y5QM64
+          name: test-e2e-electron-stable
+          requires:
+            - deploy-stage
+            - deploy-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
       - deploy-production:
           stage: beta
           requires:
-            - build-e2e-page-beta
+            - test-e2e-electron-beta
             - gcloud-setup
           filters:
             branches:
@@ -189,7 +283,7 @@ workflows:
       - deploy-production:
           stage: stable
           requires:
-            - build-e2e-page-stable
+            - test-e2e-electron-stable
             - gcloud-setup
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  build_and_test:
+  install:
     docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-components:0.0.4
     steps:
@@ -14,13 +14,20 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
+
+  test:
+    docker: *BUILDIMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
       - run: npm test
       - persist_to_workspace:
           root: .
           paths:
             - dist
 
-  gcloud_setup:
+  gcloud-setup:
     docker: &GCSIMAGE
       - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
     steps:
@@ -34,7 +41,7 @@ jobs:
           paths:
             - gcloud
 
-  generate_version:
+  generate-version:
     docker: *BUILDIMAGE
     steps:
       - run: mkdir version-string
@@ -44,7 +51,7 @@ jobs:
           paths:
             - version-string
 
-  build_e2e_page:
+  build-e2e-page:
     parameters:
       stage:
         type: string
@@ -57,7 +64,7 @@ jobs:
       - run: |
           VERSION=$(cat version-string/version)
           sed "
-            s!__STAGE__/common!<< parameters.stage >>/common/$VERSION!;
+            s!__STAGE__/common!staging/common/$VERSION!;
             s/__STAGE__/<< parameters.stage >>/;
             s!staging/components/rise-data-image/__VERSION__!<< parameters.stage >>/components/rise-data-image!;
             s/__PLAYER__/electron/;
@@ -74,7 +81,26 @@ jobs:
           paths:
             - base
 
-  deploy_to_gcs:
+  deploy-stage:
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: |
+          GS_BASE=gs://widgets.risevision.com
+          VERSION=$(cat version-string/version)
+          TARGET=$GS_BASE/staging/common/$VERSION/
+          echo Deploying version $VERSION to common
+          gsutil cp dist/*.js $TARGET
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+          gsutil acl -r ch -u AllUsers:R $TARGET
+
+  deploy-production:
     parameters:
       stage:
         type: string
@@ -88,7 +114,8 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          TARGET=gs://widgets.risevision.com/<< parameters.stage >>/common
+          GS_BASE=gs://widgets.risevision.com
+          TARGET=$GS_BASE/<< parameters.stage >>/common
           gsutil cp dist/*.js $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
@@ -96,33 +123,74 @@ jobs:
 workflows:
   workflow1:
     jobs:
-      - build_and_test
-      - generate_version
-      - gcloud_setup:
+      - install
+      - test:
+          requires:
+            - install
+      - gcloud-setup:
+          requires:
+            - install
           filters:
             branches:
               only:
+                - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-      - build_e2e_page:
+      - generate-version:
+          requires:
+            - install
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+                - build/stable
+      - deploy-stage:
+          requires:
+            - test
+            - gcloud-setup
+            - generate-version
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+                - build/stable
+      - build-e2e-page:
+          stage: beta
+          name: build-e2e-page-beta
+          requires:
+            - test
+            - generate-version
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+      - build-e2e-page:
+          stage: stable
+          name: build-e2e-page-stable
+          requires:
+            - test
+            - generate-version
+          filters:
+            branches:
+              only:
+                - build/stable
+      - deploy-production:
           stage: beta
           requires:
-            - build_and_test
-            - generate_version
-      - deploy_to_gcs:
-          stage: beta
-          requires:
-            - build_e2e_page
-            - gcloud_setup
+            - build-e2e-page-beta
+            - gcloud-setup
           filters:
             branches:
               only:
                 - master
-      - deploy_to_gcs:
+      - deploy-production:
           stage: stable
           requires:
-            - build_e2e_page
-            - gcloud_setup
+            - build-e2e-page-stable
+            - gcloud-setup
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          TARGET=$GS_BASE/<< parameters.stage >>/e2e/rise-data-image/electron
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/e2e/rise-data-image/electron
           echo Deploying << parameters.stage >> electron e2e page for rise-data-image
           gsutil rsync -d -r base $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,14 @@ jobs:
       - image: jenkinsrise/cci-v2-components:0.0.4
     steps:
       - checkout
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g gulp
       - run: npm install
+      - save_cache:
+          key: node-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
       - run: npm test
       - persist_to_workspace:
           root: .
@@ -27,6 +33,44 @@ jobs:
           root: ~/.config
           paths:
             - gcloud
+
+  generate_version:
+    docker: *BUILDIMAGE
+    steps:
+      - run: mkdir version-string
+      - run: echo $(date +%Y.%m.%d.%H.%M) > version-string/version
+      - persist_to_workspace:
+          root: .
+          paths:
+            - version-string
+
+  build_e2e_page:
+    parameters:
+      stage:
+        type: string
+    docker: *BUILDIMAGE
+    steps:
+      - attach_workspace:
+          at: .
+      - run: echo build rise-data-image e2e page << parameters.stage >>
+      - run: git clone https://github.com/Rise-Vision/rise-data-image.git
+      - run: |
+          VERSION=$(cat version-string/version)
+          sed "
+            s/__STAGE__/<< parameters.stage >>/;
+            s/__VERSION__/$VERSION/;
+            s/__PLAYER__/electron/;
+            s/__CONNECTION__/websocket/;
+          " rise-data-image/e2e/rise-data-image.html > rise-data-image/e2e/rise-data-image-electron.html
+      - run: cp rise-data-image/e2e/polymer-e2e-electron.json rise-data-image/polymer.json
+      - run: cat rise-data-image/polymer.json
+      - run: |
+          cd rise-data-image
+          polymer build
+      - persist_to_workspace:
+          root: ./rise-data-image/build
+          paths:
+            - base
 
   deploy_to_gcs:
     parameters:
@@ -51,16 +95,22 @@ workflows:
   workflow1:
     jobs:
       - build_and_test
+      - generate_version
       - gcloud_setup:
           filters:
             branches:
               only:
                 - master
                 - build/stable
-      - deploy_to_gcs:
+      - build_e2e_page:
           stage: beta
           requires:
             - build_and_test
+            - generate_version
+      - deploy_to_gcs:
+          stage: beta
+          requires:
+            - build_e2e_page
             - gcloud_setup
           filters:
             branches:
@@ -69,7 +119,7 @@ workflows:
       - deploy_to_gcs:
           stage: stable
           requires:
-            - build_and_test
+            - build_e2e_page
             - gcloud_setup
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,6 @@ jobs:
             s/__CONNECTION__/websocket/;
           " rise-data-image/e2e/rise-data-image.html > rise-data-image/e2e/rise-data-image-electron.html
       - run: cp rise-data-image/e2e/polymer-e2e-electron.json rise-data-image/polymer.json
-      - run: cat rise-data-image/e2e/rise-data-image-electron.html
       - run: |
           cd rise-data-image
           npm install
@@ -214,7 +213,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -235,7 +233,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -257,7 +254,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64


### PR DESCRIPTION
This runs the e2e tests in beta and stable branches. It was tested here:

https://circleci.com/workflow-run/c4fb5843-d704-4d97-92b8-d7aed011d972

It uses the same e2e test as rise-data-image, but in this case it uses the common-template staged page and the rise-data-image beta or stable version. The rest of the code remains the same as in that other project.
