### PR TITLE
Feature/detect preview

### DIFF
--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -40,7 +40,8 @@ RisePlayerConfiguration.Logger = (() => {
     const playerInfo = RisePlayerConfiguration.getPlayerInfo();
     const rolloutStage = playerInfo.playerType;
 
-    if ( playerInfo.playerType !== "beta" && playerInfo.playerType !== "stable" ) {
+    if ( RisePlayerConfiguration.isPreview() ||
+      ( rolloutStage !== "beta" && rolloutStage !== "stable" )) {
       _bigQueryLoggingEnabled = false;
       return;
     }

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -52,6 +52,9 @@ const RisePlayerConfiguration = {
 
     return playerInfo ? playerInfo.displayId : null;
   },
+  isPreview: function() {
+    return RisePlayerConfiguration.getDisplayId() === "preview";
+  },
   Helpers: null,
   LocalMessaging: null,
   LocalStorage: null,

--- a/test/unit/rise-logger/configuration.test.js
+++ b/test/unit/rise-logger/configuration.test.js
@@ -21,6 +21,18 @@ describe( "configure", function() {
     expect( RisePlayerConfiguration.Logger.isBigQueryLoggingEnabled()).to.be.false;
   });
 
+  it( "should not enable BQ logging if preview", function() {
+    RisePlayerConfiguration.configure({
+      displayId: "preview",
+      companyId: "COMPANY_ID",
+      playerType: "beta",
+      os: "Ubuntu 64",
+      playerVersion: "2018.01.01.10.00"
+    }, {});
+
+    expect( RisePlayerConfiguration.Logger.isBigQueryLoggingEnabled()).to.be.false;
+  });
+
   it( "should configure logging during beta stage", function() {
     RisePlayerConfiguration.configure({
       displayId: "DISPLAY_ID",

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -1,0 +1,44 @@
+/* global describe, it, expect, afterEach, beforeEach */
+
+"use strict";
+
+describe( "RisePlayerConfiguration", function() {
+
+  var _localMessaging,
+    _logger;
+
+  beforeEach( function() {
+    _logger = RisePlayerConfiguration.Logger;
+    _localMessaging = RisePlayerConfiguration.LocalMessaging;
+
+    RisePlayerConfiguration.Logger = {
+      configure: function() {}
+    };
+
+    RisePlayerConfiguration.LocalMessaging = {
+      configure: function() {}
+    };
+  });
+
+  afterEach( function() {
+    RisePlayerConfiguration.Logger = _logger;
+    RisePlayerConfiguration.LocalMessaging = _localMessaging;
+  });
+
+  describe( "isPreview", function() {
+
+    it( "should be preview if display id is 'preview'", function() {
+      RisePlayerConfiguration.configure({ displayId: "preview" });
+
+      expect( RisePlayerConfiguration.isPreview()).to.be.true;
+    });
+
+    it( "should not be preview if display id is not 'preview'", function() {
+      RisePlayerConfiguration.configure({ displayId: "test" });
+
+      expect( RisePlayerConfiguration.isPreview()).to.be.false;
+    });
+
+  });
+
+});

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -25,6 +25,68 @@ describe( "RisePlayerConfiguration", function() {
     RisePlayerConfiguration.LocalMessaging = _localMessaging;
   });
 
+  describe( "getPlayerInfo", function() {
+
+    it( "should return the player info", function() {
+      RisePlayerConfiguration.configure({ displayId: "id" });
+
+      expect( RisePlayerConfiguration.getPlayerInfo()).to.deep.equal({
+        displayId: "id"
+      });
+    });
+
+    it( "should not return the player info if there was no configuration", function() {
+      RisePlayerConfiguration.configure();
+
+      expect( RisePlayerConfiguration.getPlayerInfo()).to.be.undefined;
+    });
+
+  });
+
+  describe( "getDisplayId", function() {
+
+    it( "should return the display id", function() {
+      RisePlayerConfiguration.configure({ displayId: "id" });
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.equal( "id" );
+    });
+
+    it( "should not return the display id if it was not provided", function() {
+      RisePlayerConfiguration.configure({});
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.be.undefined;
+    });
+
+    it( "should not return the display id if there was no configuration", function() {
+      RisePlayerConfiguration.configure();
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.be.null;
+    });
+
+  });
+
+  describe( "getCompanyId", function() {
+
+    it( "should return the company id", function() {
+      RisePlayerConfiguration.configure({ companyId: "id" });
+
+      expect( RisePlayerConfiguration.getCompanyId()).to.equal( "id" );
+    });
+
+    it( "should not return the company id if it was not provided", function() {
+      RisePlayerConfiguration.configure({});
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.be.undefined;
+    });
+
+    it( "should not return the company id if there was no configuration", function() {
+      RisePlayerConfiguration.configure();
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.be.null;
+    });
+
+  });
+
   describe( "isPreview", function() {
 
     it( "should be preview if display id is 'preview'", function() {


### PR DESCRIPTION
Added isPreview() to RisePlayerConfiguration. For the moment I'm assuming displayId as "preview" as it's the case with rise-data-financial. 

We still haven't designed how a preview configuration will be set on a template page, so I'm just assuming this value will be passed there for a display id.

I'm also explicitly disabling logging during preview, although a preview page will never have beta or stable configuration, but just to make the intention more clear.

I added unit tests to isPreview and other simple configuration functions that had no tests.
