### PR TITLE
Feature/send components ready event on preview

### DIFF
--- a/src/rise-component-loader.js
+++ b/src/rise-component-loader.js
@@ -6,16 +6,7 @@ RisePlayerConfiguration.ComponentLoader = (() => {
     if ( event.detail.isConnected ) {
       window.removeEventListener( "rise-local-messaging-connection", connectionHandler );
 
-      Promise.resolve()
-        .then(() => {
-          const detail = { detail: { isLoaded: true } };
-
-          // old event, so we don't break existing pages; will be removed soon
-          window.dispatchEvent( new CustomEvent( "rise-components-loaded", detail ));
-
-          // components ready event, will be moved elsewhere after when this class disappears
-          window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
-        });
+      RisePlayerConfiguration.sendComponentsReadyEvent();
     }
   }
 

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -24,7 +24,12 @@ const RisePlayerConfiguration = {
     }
 
     RisePlayerConfiguration.Logger.configure();
-    RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
+
+    if ( RisePlayerConfiguration.isPreview()) {
+      RisePlayerConfiguration.sendComponentsReadyEvent();
+    } else {
+      RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
+    }
 
     // lock down RisePlayerConfiguration object
     if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
@@ -54,6 +59,12 @@ const RisePlayerConfiguration = {
   },
   isPreview: function() {
     return RisePlayerConfiguration.getDisplayId() === "preview";
+  },
+  sendComponentsReadyEvent() {
+    Promise.resolve()
+      .then(() => {
+        window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
+      });
   },
   Helpers: null,
   LocalMessaging: null,

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -101,6 +101,18 @@ describe( "RisePlayerConfiguration", function() {
       expect( RisePlayerConfiguration.isPreview()).to.be.false;
     });
 
+    it( "should call rise-components-ready on preview", function( done ) {
+      var connectionHandler = function() {
+        window.removeEventListener( "rise-components-ready", connectionHandler );
+
+        done();
+      };
+
+      window.addEventListener( "rise-components-ready", connectionHandler );
+
+      RisePlayerConfiguration.configure({ displayId: "preview" });
+    });
+
   });
 
 });


### PR DESCRIPTION
When on preview, the RisePlayerConfiguration now sends a rise-components-ready event, so all components will start working.

I moved the function that sends the event from RiseComponentLoader to RisePlayerConfiguration, so it could be reused.
