### PR TITLE
Fix check for message topic existence

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -23,7 +23,7 @@ RisePlayerConfiguration.Helpers = (() => {
     }
 
     RisePlayerConfiguration.LocalMessaging.receiveMessages( message => {
-      if ( invoked || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
+      if ( invoked || !message.topic || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
         return;
       }
 

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -23,7 +23,7 @@ RisePlayerConfiguration.Helpers = (() => {
     }
 
     RisePlayerConfiguration.LocalMessaging.receiveMessages( message => {
-      if ( invoked || !message.topic || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
+      if ( invoked || message.topic.toUpperCase() !== "CLIENT-LIST" ) {
         return;
       }
 

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -137,7 +137,9 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function _receiveWindowMessages( handler ) {
-    top.receiveFromPlayer( "local-messaging", handler );
+    top.receiveFromPlayer( "local-messaging", data => {
+      data.topic && typeof data.topic === "string" && handler( data );
+    });
   }
 
   function _resetForAutomatedTests() {

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -132,7 +132,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
 
   function _receiveWebsocketMessages( handler ) {
     _messageHandlers.push(( data ) => {
-      handler( data );
+      data.topic && typeof data.topic === "string" && handler( data );
     });
   }
 

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -292,6 +292,15 @@ describe( "websocket connection", function() {
 
       expect( spy ).to.be.calledWith({ topic: "TEST" });
     });
+
+    it( "should not execute handler when message is received without a topic", function() {
+      var spy = sinon.spy();
+
+      RisePlayerConfiguration.LocalMessaging.receiveMessages( spy );
+      messagingInternalDataHandler({ test: "TEST" });
+
+      expect( spy ).to.not.have.been.called;
+    });
   });
 
   describe( "broadcastMessage", function() {

--- a/test/unit/rise-local-messaging.test.js
+++ b/test/unit/rise-local-messaging.test.js
@@ -100,6 +100,18 @@ describe( "window connection", function() {
 
       expect( spy ).to.have.been.calledWith({ topic: "TEST" });
     });
+
+    it( "should not execute handler when message is received without a topic", function() {
+      var spy = sinon.spy();
+
+      top.receiveFromPlayer = function( name, handler ) {
+        // force test a message
+        handler({ test: "TEST" });
+      };
+      RisePlayerConfiguration.LocalMessaging.receiveMessages( spy );
+
+      expect( spy ).to.not.have.been.called;
+    });
   });
 
   describe( "broadcastMessage", function() {


### PR DESCRIPTION
- A message with no topic is being broadcast from Electron Player and was not being filtered out causing a script error which was _sometimes_ resulting in a watch of an image not being shown on display. 