### PR TITLE
Fix issue with e2e test process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
+                - fix/e2e
       - generate-version:
           requires:
             - install
@@ -192,6 +193,7 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
+                - fix/e2e
       - deploy-stage:
           requires:
             - build_and_test
@@ -203,6 +205,7 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
+                - fix/e2e
       - build-e2e-page:
           stage: beta
           name: build-e2e-page-beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,18 @@ jobs:
       - run:
           name: run the test
           command: |
+            if [ << parameters.stage >> = "beta" ]
+            then
+              INSTALLER_STAGE="beta/"
+            else
+              INSTALLER_STAGE=""
+            fi
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
             cd rise-launcher-electron-e2e
-            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20 << parameters.stage >>
+            curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
+            curl https://storage.googleapis.com/install-versions.risevision.com/{$INSTALLER_STAGE}installer-lnx-64.sh > installer.sh
+            chmod +x installer.sh
+            node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,8 @@ jobs:
         type: string
       displayId:
         type: string
+      installerPath:
+        type: string
     docker: &E2EIMAGE
       - image: jenkinsrise/jenkinsrise-cci-image-launcher-electron-e2e:0.0.2
         environment:
@@ -140,19 +142,17 @@ jobs:
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
       - run: echo proxy= >> $PLAYER_CONFIG
       - run:
-          name: run the test
+          name: prepare the test
           command: |
-            if [ << parameters.stage >> = "beta" ]
-            then
-              INSTALLER_STAGE="beta/"
-            else
-              INSTALLER_STAGE=""
-            fi
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
             cd rise-launcher-electron-e2e
             curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
-            curl https://storage.googleapis.com/install-versions.risevision.com/{$INSTALLER_STAGE}installer-lnx-64.sh > installer.sh
+            curl << parameters.installerPath >>installer-lnx-64.sh > installer.sh
             chmod +x installer.sh
+      - run:
+          name: run the test
+          command: |
+            cd rise-launcher-electron-e2e
             node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
@@ -255,6 +255,7 @@ workflows:
       - test-e2e-electron:
           stage: beta
           displayId: 9YP68DHZ4HUJ
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/beta/
           name: test-e2e-electron-beta
           requires:
             - deploy-stage
@@ -266,6 +267,7 @@ workflows:
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/
           name: test-e2e-electron-stable
           requires:
             - deploy-stage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,6 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-                - fix/e2e
       - generate-version:
           requires:
             - install
@@ -202,7 +201,6 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-                - fix/e2e
       - deploy-stage:
           requires:
             - build_and_test
@@ -214,7 +212,6 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-                - fix/e2e
       - build-e2e-page:
           stage: beta
           name: build-e2e-page-beta
@@ -224,7 +221,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix/e2e
+                - master
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -244,7 +241,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix/e2e
+                - master
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -265,7 +262,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix/e2e
+                - master
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64
@@ -281,7 +278,7 @@ workflows:
           stage: beta
           name: deploy-beta
           requires:
-            - deploy-stage
+            - test-e2e-electron-beta
             - gcloud-setup
           filters:
             branches:


### PR DESCRIPTION
- Pre-downloading installer and screenshot to account for using revised `test-display-runner-using-downloaded-installer.js` from rise-launcher-electron-e2e
- Re-enabling e2e test workflow