### PR TITLE
Configure display id via Viewer URL query param

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -8,12 +8,6 @@ RisePlayerConfiguration.Helpers = (() => {
     return names.every( name => _clients.indexOf( name ) >= 0 );
   }
 
-  function _getDisplaysEndpointURL() {
-    const playerType = RisePlayerConfiguration.LocalMessaging.getPlayerType();
-
-    return playerType === "electron" ? "https://localhost:9495/displays" : "http://127.0.0.1:9494/displays";
-  }
-
   function isTestEnvironment() {
     return window.env && window.env.RISE_ENV && window.env.RISE_ENV === "test";
   }
@@ -46,33 +40,20 @@ RisePlayerConfiguration.Helpers = (() => {
     });
   }
 
-  function getDisplayIdByEndpoint( callback ) {
-    const xmlhttp = new XMLHttpRequest();
-    const serverUrl = _getDisplaysEndpointURL();
+  function getDisplayIdFromViewer() {
+    let displayId = null;
 
-    xmlhttp.onreadystatechange = () => {
-      try {
-        if ( xmlhttp.readyState === 4 && xmlhttp.status === 200 ) {
-          try {
-            const responseObject = JSON.parse( xmlhttp.responseText );
+    try {
+      const href = top.location.href;
+      const reg = new RegExp( "[?&]id=([^&#]*)", "i" );
+      const string = reg.exec( href );
 
-            callback( responseObject.displayId );
-          } catch ( err ) {
-            console.log( "displays endpoint: parse error", err );
-            callback( null );
-          }
-        } else {
-          console.log( "displays endpoint: request failed", xmlhttp.status );
-          callback( null );
-        }
-      } catch ( err ) {
-        console.debug( "Caught exception: ", err.message );
-        callback( null );
-      }
-    };
+      displayId = string ? string[ 1 ] : null;
+    } catch ( err ) {
+      console.log( "can't retrieve display id via Viewer", err );
+    }
 
-    xmlhttp.open( "GET", serverUrl );
-    xmlhttp.send();
+    return displayId;
   }
 
   function reset() {
@@ -82,7 +63,7 @@ RisePlayerConfiguration.Helpers = (() => {
   const exposedFunctions = {
     isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable,
-    getDisplayIdByEndpoint: getDisplayIdByEndpoint
+    getDisplayIdFromViewer: getDisplayIdFromViewer
   };
 
   if ( isTestEnvironment()) {


### PR DESCRIPTION
- Default behaviour is to conditionally now get display id from `id` query param of Viewer URL (`top.location.href`). 
- Providing an optional param in `RisePlayerConfiguration.configure` function to force use the display id provided in  `playerInfo` object of `RisePlayerConfiguration.configure` function. This is for local testing purposes and so we can use for Financial e2e test HTML to ensure a licensed display id is used. 