### PR TITLE
Chore/remove get display

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -40,30 +40,13 @@ RisePlayerConfiguration.Helpers = (() => {
     });
   }
 
-  function getDisplayIdFromViewer() {
-    let displayId = null;
-
-    try {
-      const href = top.location.href;
-      const reg = new RegExp( "[?&]id=([^&#]*)", "i" );
-      const string = reg.exec( href );
-
-      displayId = string ? string[ 1 ] : null;
-    } catch ( err ) {
-      console.log( "can't retrieve display id via Viewer", err );
-    }
-
-    return displayId;
-  }
-
   function reset() {
     _clients = [];
   }
 
   const exposedFunctions = {
     isTestEnvironment: isTestEnvironment,
-    onceClientsAreAvailable: onceClientsAreAvailable,
-    getDisplayIdFromViewer: getDisplayIdFromViewer
+    onceClientsAreAvailable: onceClientsAreAvailable
   };
 
   if ( isTestEnvironment()) {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,7 +1,7 @@
 /* eslint-disable one-var */
 
 const RisePlayerConfiguration = {
-  configure: ( playerInfo, localMessagingInfo, usePlayerInfoForDisplayId = false ) => {
+  configure: ( playerInfo, localMessagingInfo ) => {
     if ( !playerInfo && !localMessagingInfo ) {
       // outside of viewer or inside of viewer
       const getConfiguration = window.getRisePlayerConfiguration ||

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -19,8 +19,6 @@ const RisePlayerConfiguration = {
       } else {
         throw new Error( "No configuration was provided" );
       }
-    } else {
-      throw new Error( "No configuration was provided" );
     }
 
     RisePlayerConfiguration.getPlayerInfo = () => playerInfo;

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -20,14 +20,7 @@ const RisePlayerConfiguration = {
         throw new Error( "No configuration was provided" );
       }
     } else {
-      // remove this block once all demos are updated
-      const playerInfoDisplayId = playerInfo ? playerInfo.displayId : null;
-
-      if ( !usePlayerInfoForDisplayId && !RisePlayerConfiguration.Helpers.isTestEnvironment() && playerInfoDisplayId !== "preview" ) {
-        const displayId = RisePlayerConfiguration.Helpers.getDisplayIdFromViewer();
-
-        playerInfo.displayId = displayId ? displayId : playerInfoDisplayId;
-      }
+      throw new Error( "No configuration was provided" );
     }
 
     RisePlayerConfiguration.getPlayerInfo = () => playerInfo;


### PR DESCRIPTION
Removes the code that gets the display id from viewer.

This shouldn't be merged until all template pages are updated to use player configuration.
