### PR TITLE
Feature/receive presentation id

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -40,11 +40,26 @@ RisePlayerConfiguration.Helpers = (() => {
     });
   }
 
+  function getHttpParameter( name ) {
+    try {
+      const href = top.location.href;
+      const regex = new RegExp( `[?&]${ name }=([^&#]*)`, "i" );
+      const match = regex.exec( href );
+
+      return match ? match[ 1 ] : null;
+    } catch ( err ) {
+      console.log( "can't retrieve HTTP parameter", err );
+
+      return null;
+    }
+  }
+
   function reset() {
     _clients = [];
   }
 
   const exposedFunctions = {
+    getHttpParameter: getHttpParameter,
     isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable
   };

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, one-var */
+/* eslint-disable one-var */
 
 const RisePlayerConfiguration = {
   configure: ( playerInfo, localMessagingInfo ) => {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,4 +1,4 @@
-/* eslint-disable one-var */
+/* eslint-disable no-console, one-var */
 
 const RisePlayerConfiguration = {
   configure: ( playerInfo, localMessagingInfo ) => {
@@ -90,6 +90,15 @@ const RisePlayerConfiguration = {
     var playerInfo = RisePlayerConfiguration.getPlayerInfo();
 
     return playerInfo ? playerInfo.displayId : null;
+  },
+  getPresentationId: function() {
+    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+
+    if ( playerInfo && playerInfo.presentationId ) {
+      return playerInfo.presentationId;
+    }
+
+    return RisePlayerConfiguration.Helpers.getHttpParameter( "presentationId" );
   },
   isPreview: function() {
     return RisePlayerConfiguration.getDisplayId() === "preview";

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -4,12 +4,18 @@
 
 describe( "RisePlayerConfiguration", function() {
 
-  var _localMessaging,
+  var _helpers,
+    _localMessaging,
     _logger;
 
   beforeEach( function() {
+    _helpers = RisePlayerConfiguration.Helpers;
     _logger = RisePlayerConfiguration.Logger;
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
+
+    RisePlayerConfiguration.Helpers = {
+      isTestEnvironment: _helpers.isTestEnvironment
+    };
 
     RisePlayerConfiguration.Logger = {
       configure: function() {}
@@ -21,6 +27,7 @@ describe( "RisePlayerConfiguration", function() {
   });
 
   afterEach( function() {
+    RisePlayerConfiguration.Helpers = _helpers;
     RisePlayerConfiguration.Logger = _logger;
     RisePlayerConfiguration.LocalMessaging = _localMessaging;
   });
@@ -83,6 +90,36 @@ describe( "RisePlayerConfiguration", function() {
       RisePlayerConfiguration.configure({});
 
       expect( RisePlayerConfiguration.getDisplayId()).to.be.undefined;
+    });
+
+  });
+
+  describe( "getPresentationId", function() {
+
+    it( "should return the presentation id", function() {
+      RisePlayerConfiguration.configure({ presentationId: "id" });
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.equal( "id" );
+    });
+
+    it( "should not return the presentation id if it was not provided", function() {
+      RisePlayerConfiguration.Helpers.getHttpParameter = function() {
+        return null;
+      }
+
+      RisePlayerConfiguration.configure({});
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.be.null;
+    });
+
+    it( "should return the presentation id if it's available as HTTP parameter", function() {
+      RisePlayerConfiguration.Helpers.getHttpParameter = function() {
+        return "id";
+      }
+
+      RisePlayerConfiguration.configure({});
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.equal( "id" );
     });
 
   });


### PR DESCRIPTION
Receive the presentation id as part of playerInfo; in this case if it's not present we'll extract it as an HTTP parameter so we can test this before Player supports it.
