### PR TITLE
Staging/watch attribute data file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,8 @@
       "src/rise-heartbeat.js",
       "src/rise-licensing.js",
       "src/rise-logger.js",
-      "src/rise-local-storage.js"
+      "src/rise-local-storage.js",
+      "src/rise-watch.js"
     ];
 
   gulp.task( "clean", function( cb ) {

--- a/src/config/config-prod.js
+++ b/src/config/config-prod.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
 
 const TEMPLATE_COMMON_CONFIG = {
+  GCS_ATTRIBUTE_DATA_FILE: "attribute-data.json",
+  GCS_COMPANY_BUCKET: "risevision-company-notifications",
   LOGGER_CLIENT_ID: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
   LOGGER_CLIENT_SECRET: "nlZyrcPLg6oEwO9f9Wfn29Wh",
   LOGGER_REFRESH_TOKEN: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",

--- a/src/config/config-test.js
+++ b/src/config/config-test.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
 
 const TEMPLATE_COMMON_CONFIG = {
+  GCS_ATTRIBUTE_DATA_FILE: "attribute-data.json",
+  GCS_COMPANY_BUCKET: "risevision-company-notifications",
   LOGGER_CLIENT_ID: "1088527147109-6q1o2vtihn34292pjt4ckhmhck0rk0o7.apps.googleusercontent.com",
   LOGGER_CLIENT_SECRET: "nlZyrcPLg6oEwO9f9Wfn29Wh",
   LOGGER_REFRESH_TOKEN: "1/xzt4kwzE1H7W9VnKB8cAaCx6zb4Es4nKEoqaYHdTD15IgOrJDtdun6zK6XiATCKT",

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -110,6 +110,10 @@ const RisePlayerConfiguration = {
     Promise.resolve()
       .then(() => {
         window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
+
+        if ( !RisePlayerConfiguration.isPreview()) {
+          RisePlayerConfiguration.Watch.watchAttributeDataFile();
+        }
       });
   },
   Helpers: null,

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -41,6 +41,9 @@ const RisePlayerConfiguration = {
     if ( !RisePlayerConfiguration.Heartbeat ) {
       throw new Error( "RiseHeartbeat script was not loaded" );
     }
+    if ( !RisePlayerConfiguration.Watch ) {
+      throw new Error( "RiseWatch script was not loaded" );
+    }
 
     RisePlayerConfiguration.Logger.configure();
 

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -1,5 +1,29 @@
+/* global TEMPLATE_COMMON_CONFIG */
+/* eslint-disable one-var */
+
 RisePlayerConfiguration.Watch = (() => {
 
-  return {};
+  function watchAttributeDataFile() {
+    const companyId = RisePlayerConfiguration.getCompanyId();
+    const presentationId = RisePlayerConfiguration.getPresentationId();
+
+    const filePath = `${
+      TEMPLATE_COMMON_CONFIG.GCS_COMPANY_BUCKET
+    }/${
+      companyId
+    }/template-data/${
+      presentationId
+    }/published/${
+      TEMPLATE_COMMON_CONFIG.GCS_ATTRIBUTE_DATA_FILE
+    }`;
+
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( filePath, () => {
+      // handle response
+    });
+  }
+
+  return {
+    watchAttributeDataFile: watchAttributeDataFile
+  };
 
 })();

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -1,11 +1,17 @@
 /* global TEMPLATE_COMMON_CONFIG */
-/* eslint-disable one-var */
+/* eslint-disable no-console, one-var */
 
 RisePlayerConfiguration.Watch = (() => {
 
   function watchAttributeDataFile() {
     const companyId = RisePlayerConfiguration.getCompanyId();
     const presentationId = RisePlayerConfiguration.getPresentationId();
+
+    if ( !presentationId ) {
+      console.log( "No presentation id available; can't send attribute data file watch" );
+
+      return;
+    }
 
     const filePath = `${
       TEMPLATE_COMMON_CONFIG.GCS_COMPANY_BUCKET

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -24,13 +24,24 @@ RisePlayerConfiguration.Watch = (() => {
       TEMPLATE_COMMON_CONFIG.GCS_ATTRIBUTE_DATA_FILE
     }`;
 
-    RisePlayerConfiguration.LocalStorage.watchSingleFile( filePath, () => {
-      // handle response
+    RisePlayerConfiguration.LocalStorage.watchSingleFile( filePath, _handleFileUpdateMessage );
+  }
+
+  function _handleFileUpdateMessage( message ) {
+    // handle response in a following PR
+    console.log( JSON.stringify( message ));
+  }
+
+  const exposedFunctions = {
+    watchAttributeDataFile: watchAttributeDataFile
+  };
+
+  if ( RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+    Object.assign( exposedFunctions, {
+      handleFileUpdateMessage: _handleFileUpdateMessage
     });
   }
 
-  return {
-    watchAttributeDataFile: watchAttributeDataFile
-  };
+  return exposedFunctions;
 
 })();

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -8,6 +8,7 @@ RisePlayerConfiguration.Watch = (() => {
     const presentationId = RisePlayerConfiguration.getPresentationId();
 
     if ( !presentationId ) {
+      // current templates won't have a presentation id, so they will make this far
       console.log( "No presentation id available; can't send attribute data file watch" );
 
       return;

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -1,0 +1,5 @@
+RisePlayerConfiguration.Watch = (() => {
+
+  return {};
+
+})();

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -1,0 +1,11 @@
+/* global describe, it, expect */
+
+"use strict";
+
+describe( "Watch", function() {
+
+  it( "should exist", function() {
+    expect( RisePlayerConfiguration.Watch ).to.be.ok;
+  });
+
+});

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -41,4 +41,16 @@ describe( "Watch", function() {
     expect( call.args[ 1 ]).to.be.a( "function" );
   });
 
+  it( "should not send watch if presentation id is not present", function() {
+
+    RisePlayerConfiguration.getPresentationId.restore();
+    sinon.stub( RisePlayerConfiguration, "getPresentationId", function() {
+      return null;
+    });
+
+    RisePlayerConfiguration.Watch.watchAttributeDataFile();
+
+    expect( RisePlayerConfiguration.LocalStorage.watchSingleFile.called ).to.be.false;
+  });
+
 });

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -1,11 +1,44 @@
-/* global describe, it, expect */
+/* global afterEach, beforeEach, describe, it, expect, sinon */
+/* eslint-disable vars-on-top */
 
 "use strict";
 
 describe( "Watch", function() {
 
+  beforeEach( function() {
+    sinon.stub( RisePlayerConfiguration.LocalStorage, "watchSingleFile" );
+
+    sinon.stub( RisePlayerConfiguration, "getCompanyId", function() {
+      return "COMPANY_ID";
+    });
+    sinon.stub( RisePlayerConfiguration, "getPresentationId", function() {
+      return "PRESENTATION_ID";
+    });
+  });
+
+  afterEach( function() {
+    RisePlayerConfiguration.getCompanyId.restore();
+    RisePlayerConfiguration.getPresentationId.restore();
+    RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+  });
+
   it( "should exist", function() {
     expect( RisePlayerConfiguration.Watch ).to.be.ok;
+  });
+
+  it( "should send watch for attribute data file", function() {
+
+    RisePlayerConfiguration.Watch.watchAttributeDataFile();
+
+    expect( RisePlayerConfiguration.LocalStorage.watchSingleFile.called ).to.be.true;
+
+    var call = RisePlayerConfiguration.LocalStorage.watchSingleFile.getCall( 0 );
+
+    expect( call ).to.be.ok;
+    expect( call.args[ 0 ]).to.equal(
+      "risevision-company-notifications/COMPANY_ID/template-data/PRESENTATION_ID/published/attribute-data.json"
+    );
+    expect( call.args[ 1 ]).to.be.a( "function" );
   });
 
 });

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -30,15 +30,10 @@ describe( "Watch", function() {
 
     RisePlayerConfiguration.Watch.watchAttributeDataFile();
 
-    expect( RisePlayerConfiguration.LocalStorage.watchSingleFile.called ).to.be.true;
-
-    var call = RisePlayerConfiguration.LocalStorage.watchSingleFile.getCall( 0 );
-
-    expect( call ).to.be.ok;
-    expect( call.args[ 0 ]).to.equal(
-      "risevision-company-notifications/COMPANY_ID/template-data/PRESENTATION_ID/published/attribute-data.json"
+    expect( RisePlayerConfiguration.LocalStorage.watchSingleFile ).to.have.been.calledWith(
+      "risevision-company-notifications/COMPANY_ID/template-data/PRESENTATION_ID/published/attribute-data.json",
+      RisePlayerConfiguration.Watch.handleFileUpdateMessage
     );
-    expect( call.args[ 1 ]).to.be.a( "function" );
   });
 
   it( "should not send watch if presentation id is not present", function() {


### PR DESCRIPTION
Sends the watch, with unit tests.

I tested this manually by scheduling an image demo pointing to this branch here:

https://apps-stage-9.risevision.com/schedules/details/e0fc0433-ee93-4a9f-a2a3-6eadfdef52c3?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

This includes the presentationId of a valid presentation that has a attribute data file published:

http://widgets.risevision.com/staging/pages/2019.03.14.12.00/src/rise-data-image.html?presentationId=d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a

Template attribute data here:

https://console.cloud.google.com/storage/browser/risevision-company-notifications/cf85e5c4-9439-40ce-94d6-e5ea6ea2411c/template-data/d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a/revised/?project=avid-life-623

When it ran in Player, it sent the watch and the file was correctly recognized after a few seconds. Stale and current messages in console [here](https://trello-attachments.s3.amazonaws.com/55b10a8302680b3aea04ed90/5c818ded9ccd4175fe3d290b/dceb20ec5b7a57bfe635e257beccdc8a/watch_response.png).

