### PR TITLE
Feature/detect editable components

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -1,8 +1,9 @@
-/* eslint-disable no-console, one-var */
+/* eslint-disable no-console, one-var, vars-on-top */
 
 RisePlayerConfiguration.Helpers = (() => {
 
   let _clients = [];
+  let _riseElements = null;
 
   function _clientsAreAvailable( names ) {
     return names.every( name => _clients.indexOf( name ) >= 0 );
@@ -54,12 +55,33 @@ RisePlayerConfiguration.Helpers = (() => {
     }
   }
 
+  function getRiseElements() {
+    if ( _riseElements === null ) {
+      _riseElements = [];
+
+      const all = document.getElementsByTagName( "*" );
+
+      for ( var i = 0; i < all.length; i++ ) {
+        const element = all[ i ];
+        const name = element.tagName.toLowerCase();
+
+        if ( /^rise-/.test( name )) {
+          _riseElements.push( element );
+        }
+      }
+    }
+
+    return _riseElements;
+  }
+
   function reset() {
     _clients = [];
+    _riseElements = null;
   }
 
   const exposedFunctions = {
     getHttpParameter: getHttpParameter,
+    getRiseElements: getRiseElements,
     isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable
   };

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -74,6 +74,11 @@ RisePlayerConfiguration.Helpers = (() => {
     return _riseElements;
   }
 
+  function getRiseEditableElements() {
+    return getRiseElements()
+      .filter( element => !element.hasAttribute( "non-editable" ))
+  }
+
   function reset() {
     _clients = [];
     _riseElements = null;
@@ -82,6 +87,7 @@ RisePlayerConfiguration.Helpers = (() => {
   const exposedFunctions = {
     getHttpParameter: getHttpParameter,
     getRiseElements: getRiseElements,
+    getRiseEditableElements: getRiseEditableElements,
     isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable
   };

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -1,9 +1,52 @@
 
-/* global describe, it, expect, afterEach, beforeEach, sinon */
+/* global describe, document, it, expect, afterEach, beforeEach, sinon */
 
 "use strict";
 
-describe( "window connection", function() {
+describe( "Helpers", function() {
+
+  afterEach( function() {
+    RisePlayerConfiguration.Helpers.reset();
+
+    document.getElementsByTagName.restore();
+  });
+
+  describe( "getRiseElements", function() {
+
+    beforeEach( function() {
+      sinon.stub( document, "getElementsByTagName", function() {
+        return [
+          { tagName: "HTML" },
+          { tagName: "HEAD" },
+          { tagName: "BODY" },
+          {
+            tagName: "RISE-DATA-IMAGE"
+          },
+          {
+            tagName: "RISE-DATA-FINANCIAL"
+          },
+          {
+            tagName: "RISE-IMAGE"
+          },
+          { tagName: "P" }
+        ];
+      });
+    });
+
+    it( "should get list of rise elements", function() {
+      var elements = RisePlayerConfiguration.Helpers.getRiseElements();
+
+      expect( elements ).to.be.ok;
+      expect( elements.length ).to.equal( 3 );
+      expect( elements[ 0 ].tagName ).to.equal( "RISE-DATA-IMAGE" );
+      expect( elements[ 1 ].tagName ).to.equal( "RISE-DATA-FINANCIAL" );
+      expect( elements[ 2 ].tagName ).to.equal( "RISE-IMAGE" );
+    });
+  });
+
+});
+
+describe( "Helpers / window connection", function() {
 
   afterEach( function() {
     delete top.postToPlayer;
@@ -28,7 +71,7 @@ describe( "window connection", function() {
 
 });
 
-describe( "websocket connection", function() {
+describe( "Helpers / websocket connection", function() {
 
   var socketInstance,
     clock;

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -5,6 +5,35 @@
 
 describe( "Helpers", function() {
 
+  beforeEach( function() {
+    sinon.stub( document, "getElementsByTagName", function() {
+      return [
+        { tagName: "HTML" },
+        { tagName: "HEAD" },
+        { tagName: "BODY" },
+        {
+          tagName: "RISE-DATA-IMAGE",
+          hasAttribute: function() {
+            return true;
+          }
+        },
+        {
+          tagName: "RISE-DATA-FINANCIAL",
+          hasAttribute: function() {
+            return false;
+          }
+        },
+        {
+          tagName: "RISE-IMAGE",
+          hasAttribute: function() {
+            return false;
+          }
+        },
+        { tagName: "P" }
+      ];
+    });
+  });
+
   afterEach( function() {
     RisePlayerConfiguration.Helpers.reset();
 
@@ -12,26 +41,6 @@ describe( "Helpers", function() {
   });
 
   describe( "getRiseElements", function() {
-
-    beforeEach( function() {
-      sinon.stub( document, "getElementsByTagName", function() {
-        return [
-          { tagName: "HTML" },
-          { tagName: "HEAD" },
-          { tagName: "BODY" },
-          {
-            tagName: "RISE-DATA-IMAGE"
-          },
-          {
-            tagName: "RISE-DATA-FINANCIAL"
-          },
-          {
-            tagName: "RISE-IMAGE"
-          },
-          { tagName: "P" }
-        ];
-      });
-    });
 
     it( "should get list of rise elements", function() {
       var elements = RisePlayerConfiguration.Helpers.getRiseElements();
@@ -41,6 +50,18 @@ describe( "Helpers", function() {
       expect( elements[ 0 ].tagName ).to.equal( "RISE-DATA-IMAGE" );
       expect( elements[ 1 ].tagName ).to.equal( "RISE-DATA-FINANCIAL" );
       expect( elements[ 2 ].tagName ).to.equal( "RISE-IMAGE" );
+    });
+  });
+
+  describe( "getRiseEditableElements", function() {
+
+    it( "should get list of rise editable elements", function() {
+      var elements = RisePlayerConfiguration.Helpers.getRiseEditableElements();
+
+      expect( elements ).to.be.ok;
+      expect( elements.length ).to.equal( 2 );
+      expect( elements[ 0 ].tagName ).to.equal( "RISE-DATA-FINANCIAL" );
+      expect( elements[ 1 ].tagName ).to.equal( "RISE-IMAGE" );
     });
   });
 


### PR DESCRIPTION
This gets the list of editable Rise Vision components from the page elements.

I tested manually and it works as expected in both Electron Player and ChromeOS Player using this schedule:

https://apps-stage-9.risevision.com/schedules/details/e0fc0433-ee93-4a9f-a2a3-6eadfdef52c3?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
