### PR TITLE
Send start event when there is no presentation id

### DIFF
--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -23,7 +23,7 @@ RisePlayerConfiguration.Watch = (() => {
         "Can't send attribute data file watch"
       );
 
-      return;
+      return _sendStartEvent();
     }
 
     const filePath = `${

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -5,7 +5,26 @@
 
 describe( "Watch", function() {
 
+  var editableElements;
+
+  beforeEach( function() {
+
+    editableElements = [
+      { id: "rise-data-image-01" },
+      { id: "rise-data-financial-01" }
+    ];
+
+    sinon.stub( RisePlayerConfiguration.Helpers, "getRiseEditableElements", function() {
+      return editableElements;
+    });
+
+    sinon.stub( RisePlayerConfiguration.Helpers, "sendStartEvent" );
+  });
+
   afterEach( function() {
+    RisePlayerConfiguration.Helpers.getRiseEditableElements.restore();
+    RisePlayerConfiguration.Helpers.sendStartEvent.restore();
+
     RisePlayerConfiguration.Watch.reset();
   });
 
@@ -52,21 +71,15 @@ describe( "Watch", function() {
       RisePlayerConfiguration.Watch.watchAttributeDataFile();
 
       expect( RisePlayerConfiguration.LocalStorage.watchSingleFile.called ).to.be.false;
+      expect( RisePlayerConfiguration.Helpers.getRiseEditableElements.called ).to.be.true;
+      expect( RisePlayerConfiguration.Helpers.sendStartEvent.called ).to.be.true;
     });
 
   });
 
   describe( "handleAttributeDataFileUpdateMessage", function() {
 
-    var editableElements;
-
     beforeEach( function() {
-
-      editableElements = [
-        { id: "rise-data-image-01" },
-        { id: "rise-data-financial-01" }
-      ];
-
       sinon.stub( RisePlayerConfiguration.Helpers, "getLocalMessagingJsonContent", function() {
         return Promise.resolve({
           components: [
@@ -77,18 +90,10 @@ describe( "Watch", function() {
           ]
         });
       });
-
-      sinon.stub( RisePlayerConfiguration.Helpers, "getRiseEditableElements", function() {
-        return editableElements;
-      });
-
-      sinon.stub( RisePlayerConfiguration.Helpers, "sendStartEvent" );
     });
 
     afterEach( function() {
       RisePlayerConfiguration.Helpers.getLocalMessagingJsonContent.restore();
-      RisePlayerConfiguration.Helpers.getRiseEditableElements.restore();
-      RisePlayerConfiguration.Helpers.sendStartEvent.restore();
     });
 
     it( "should do nothing if there is no status", function() {


### PR DESCRIPTION
A final PR for common-template !

I noticed that if presentation id is not provided, the start event will never be sent to editable components. This sends the start event so at least those components can display default data ( as it also happens when a RLS version occurs ).
