### PR TITLE
use window instead of top

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -43,7 +43,7 @@ RisePlayerConfiguration.Helpers = (() => {
 
   function getHttpParameter( name ) {
     try {
-      const href = top.location.href;
+      const href = window.location.href;
       const regex = new RegExp( `[?&]${ name }=([^&#]*)`, "i" );
       const match = regex.exec( href );
 


### PR DESCRIPTION
Using window instead of top allows a page read the parameter from the URL loaded in its iframe, and still works for pages not loaded in an iframe.
