### PR TITLE
log rise-components-ready

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,6 +1,11 @@
 /* eslint-disable one-var */
 
 const RisePlayerConfiguration = {
+  RISE_PLAYER_CONFIGURATION_DATA: {
+    name: "RisePlayerConfiguration",
+    id: "RisePlayerConfiguration",
+    version: "N/A"
+  },
   configure: ( playerInfo, localMessagingInfo ) => {
     if ( !playerInfo && !localMessagingInfo ) {
       // outside of viewer or inside of viewer
@@ -112,6 +117,11 @@ const RisePlayerConfiguration = {
         window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
 
         if ( !RisePlayerConfiguration.isPreview()) {
+          RisePlayerConfiguration.Logger.info(
+            RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA,
+            "rise-components-ready"
+          );
+
           RisePlayerConfiguration.Watch.watchAttributeDataFile();
         }
       });


### PR DESCRIPTION
Implementation of the HTML template usage document discussed this morning.

Tested manually using this schedule:

https://apps.risevision.com/schedules/details/a5c11584-332e-457d-af95-377a96c0a6fa?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

which provided the expected entry:

```
#StandardSQL

SELECT ts, source, level, event FROM `client-side-events.Display_Events.events_test` 
WHERE ts >= "2019-03-22 00:00:00" AND ts < "2019-03-23 00:00:00"
AND display_id = 'DTPNKPGM7X56'
ORDER BY ts DESC
```
