### PR TITLE
Log template name to BQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,6 @@ jobs:
             s/__PLAYER__/electron/;
             s/__CONNECTION__/websocket/;
           " rise-data-image/e2e/rise-data-image.html > $DEST_FILE
-          NEW_EXPR="<head><script>var TEMPLATE_PRODUCT_CODE='';var TEMPLATE_VERSION='';</script>"
-          sed -i.bak '0,/<head>/{s@<head>@'"$NEW_EXPR"'@}' $DEST_FILE && rm $DEST_FILE.bak
       - run: cp rise-data-image/e2e/polymer-e2e-electron.json rise-data-image/polymer.json
       - run: |
           cd rise-data-image

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   "globals": {
     "RisePlayerConfiguration": true,
     "TEMPLATE_PRODUCT_CODE": true,
-    "TEMPLATE_VERSION": true
+    "TEMPLATE_VERSION": true,
+    "TEMPLATE_NAME": true
   }
 };

--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -81,6 +81,7 @@ RisePlayerConfiguration.Logger = (() => {
       "template": {
         "product_code": TEMPLATE_PRODUCT_CODE ? TEMPLATE_PRODUCT_CODE : "",
         "version": TEMPLATE_VERSION ? TEMPLATE_VERSION : "",
+        "name": TEMPLATE_NAME ? TEMPLATE_NAME : "",
         "presentation_id": RisePlayerConfiguration.getPresentationId()
       }
     };

--- a/test/test_env.js
+++ b/test/test_env.js
@@ -3,13 +3,16 @@ window.env.RISE_ENV = "test";
 
 TEMPLATE_PRODUCT_CODE = "TEMPLATE_PRODUCT_CODE";
 TEMPLATE_VERSION = "TEMPLATE_VERSION";
+TEMPLATE_NAME = "TEMPLATE_NAME";
 
 window.mockNoInjectedConstants = function() {
   TEMPLATE_PRODUCT_CODE = undefined;
   TEMPLATE_VERSION = undefined;
+  TEMPLATE_NAME = undefined;
 };
 
 window.resetInjectedConstants = function() {
   TEMPLATE_PRODUCT_CODE = "TEMPLATE_PRODUCT_CODE";
   TEMPLATE_VERSION = "TEMPLATE_VERSION";
+  TEMPLATE_NAME = "TEMPLATE_NAME";
 };

--- a/test/unit/rise-logger/configuration.test.js
+++ b/test/unit/rise-logger/configuration.test.js
@@ -59,6 +59,7 @@ describe( "configure", function() {
       "template": {
         "product_code": "TEMPLATE_PRODUCT_CODE",
         "version": "TEMPLATE_VERSION",
+        "name": "TEMPLATE_NAME",
         "presentation_id": "PRESENTATION_ID"
       }
     });
@@ -90,6 +91,7 @@ describe( "configure", function() {
       "template": {
         "product_code": "TEMPLATE_PRODUCT_CODE",
         "version": "TEMPLATE_VERSION",
+        "name": "TEMPLATE_NAME",
         "presentation_id": "PRESENTATION_ID"
       }
     });
@@ -122,6 +124,7 @@ describe( "configure", function() {
       "template": {
         "product_code": "TEMPLATE_PRODUCT_CODE",
         "version": "TEMPLATE_VERSION",
+        "name": "TEMPLATE_NAME",
         "presentation_id": "PRESENTATION_ID"
       }
     });
@@ -153,6 +156,7 @@ describe( "configure", function() {
       "template": {
         "product_code": "",
         "version": "",
+        "name": "",
         "presentation_id": "PRESENTATION_ID"
       }
     });

--- a/test/unit/rise-logger/log-entry.test.js
+++ b/test/unit/rise-logger/log-entry.test.js
@@ -66,6 +66,7 @@ describe( "log-entry", function() {
         "template": {
           "product_code": "TEMPLATE_PRODUCT_CODE",
           "version": "TEMPLATE_VERSION",
+          "name": "TEMPLATE_NAME",
           "presentation_id": "PRESENTATION_ID"
         }
       });
@@ -102,6 +103,7 @@ describe( "log-entry", function() {
         "template": {
           "product_code": "TEMPLATE_PRODUCT_CODE",
           "version": "TEMPLATE_VERSION",
+          "name": "TEMPLATE_NAME",
           "presentation_id": "PRESENTATION_ID"
         }
       });
@@ -136,6 +138,7 @@ describe( "log-entry", function() {
         "template": {
           "product_code": "TEMPLATE_PRODUCT_CODE",
           "version": "TEMPLATE_VERSION",
+          "name": "TEMPLATE_NAME",
           "presentation_id": "PRESENTATION_ID"
         }
       });
@@ -172,6 +175,7 @@ describe( "log-entry", function() {
         "template": {
           "product_code": "TEMPLATE_PRODUCT_CODE",
           "version": "TEMPLATE_VERSION",
+          "name": "TEMPLATE_NAME",
           "presentation_id": "PRESENTATION_ID"
         }
       });


### PR DESCRIPTION
- Additionally logging template name to BQ
- Template name will be inserted in the templates when I merge https://github.com/Rise-Vision/html-template-library/pull/25 and then deploy the templates to beta & stable
- Now that we ensure an empty string fallback for the injected constants, removing the injection of them in the e2e page

I will validate an entry to `events_test` table once I deploy a template, please review for the meantime. 
