### PR TITLE
dont send watch if there are no editable components

### DIFF
--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -26,6 +26,11 @@ RisePlayerConfiguration.Watch = (() => {
       return _sendStartEvent();
     }
 
+    // No need to get attribute data or sending start if there are no editable elements.
+    if ( RisePlayerConfiguration.Helpers.getRiseEditableElements().length === 0 ) {
+      return;
+    }
+
     const filePath = `${
       TEMPLATE_COMMON_CONFIG.GCS_COMPANY_BUCKET
     }/${


### PR DESCRIPTION
Avoid wasting resources downloading attribute data if it won't be used in the page, and may not even exist ( template pages with no editable components ).
