### PR TITLE
Enable template to receive attribute data

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,8 @@
       "src/rise-licensing.js",
       "src/rise-logger.js",
       "src/rise-local-storage.js",
-      "src/rise-watch.js"
+      "src/rise-watch.js",
+      "src/rise-preview.js"
     ];
 
   gulp.task( "clean", function( cb ) {

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -79,6 +79,18 @@ RisePlayerConfiguration.Helpers = (() => {
       .filter( element => !element.hasAttribute( "non-editable" ))
   }
 
+  function getRisePlayerConfiguration() {
+    let configuration = null;
+
+    try {
+      configuration = window.getRisePlayerConfiguration || window.top.getRisePlayerConfiguration;
+    } catch ( err ) {
+      console.log( err );
+    }
+
+    return configuration;
+  }
+
   function getLocalMessagingTextContent( fileUrl ) {
     return new Promise(( resolve, reject ) => {
       const xhr = new XMLHttpRequest();
@@ -134,6 +146,7 @@ RisePlayerConfiguration.Helpers = (() => {
     getLocalMessagingTextContent: getLocalMessagingTextContent,
     getRiseElements: getRiseElements,
     getRiseEditableElements: getRiseEditableElements,
+    getRisePlayerConfiguration: getRisePlayerConfiguration,
     isTestEnvironment: isTestEnvironment,
     onceClientsAreAvailable: onceClientsAreAvailable,
     sendStartEvent: sendStartEvent

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -9,8 +9,7 @@ const RisePlayerConfiguration = {
   configure: ( playerInfo, localMessagingInfo ) => {
     if ( !playerInfo && !localMessagingInfo ) {
       // outside of viewer or inside of viewer
-      const getConfiguration = window.getRisePlayerConfiguration ||
-        window.top.getRisePlayerConfiguration;
+      const getConfiguration = RisePlayerConfiguration.Helpers.getRisePlayerConfiguration();
 
       if ( typeof getConfiguration === "function" ) {
         const configuration = getConfiguration();
@@ -21,8 +20,6 @@ const RisePlayerConfiguration = {
         } else {
           throw new Error( `The configuration object is not valid: ${ JSON.stringify( configuration ) }` );
         }
-      } else {
-        throw new Error( "No configuration was provided" );
       }
     }
 
@@ -48,6 +45,9 @@ const RisePlayerConfiguration = {
     }
     if ( !RisePlayerConfiguration.Watch ) {
       throw new Error( "RiseWatch script was not loaded" );
+    }
+    if ( !RisePlayerConfiguration.Preview ) {
+      throw new Error( "RisePreview script was not loaded" );
     }
 
     RisePlayerConfiguration.Logger.configure();
@@ -132,6 +132,8 @@ const RisePlayerConfiguration = {
           );
 
           RisePlayerConfiguration.Watch.watchAttributeDataFile();
+        } else {
+          RisePlayerConfiguration.Preview.startListeningForData();
         }
       });
   },

--- a/src/rise-preview.js
+++ b/src/rise-preview.js
@@ -2,7 +2,7 @@
 
 RisePlayerConfiguration.Preview = (() => {
 
-  function _receiveData() {
+  function _receiveData( event ) {
     if ( event.origin.indexOf( "risevision.com" ) === -1 ) {
       return;
     }
@@ -21,6 +21,12 @@ RisePlayerConfiguration.Preview = (() => {
   const exposedFunctions = {
     startListeningForData: startListeningForData
   };
+
+  if ( RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+    Object.assign( exposedFunctions, {
+      receiveData: _receiveData
+    });
+  }
 
   return exposedFunctions;
 

--- a/src/rise-preview.js
+++ b/src/rise-preview.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+
+RisePlayerConfiguration.Preview = (() => {
+
+  function _receiveData() {
+    if ( event.origin.indexOf( "risevision.com" ) === -1 ) {
+      return;
+    }
+
+    const data = JSON.parse( event.data );
+
+    console.log( "received message with attribute data", data );
+
+    // TODO: apply data to components
+  }
+
+  function startListeningForData() {
+    window.addEventListener( "message", _receiveData );
+  }
+
+  const exposedFunctions = {
+    startListeningForData: startListeningForData
+  };
+
+  return exposedFunctions;
+
+})();

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -14,7 +14,8 @@ describe( "RisePlayerConfiguration", function() {
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
 
     RisePlayerConfiguration.Helpers = {
-      isTestEnvironment: _helpers.isTestEnvironment
+      isTestEnvironment: _helpers.isTestEnvironment,
+      getRisePlayerConfiguration: _helpers.getRisePlayerConfiguration
     };
 
     RisePlayerConfiguration.Logger = {

--- a/test/unit/rise-preview.test.js
+++ b/test/unit/rise-preview.test.js
@@ -1,0 +1,28 @@
+/* global describe, it, sinon, expect */
+/* eslint-disable no-console */
+
+"use strict";
+
+describe( "Preview", function() {
+
+  it( "should receive data from a 'message'", function() {
+    sinon.stub( console, "log" );
+
+    RisePlayerConfiguration.Preview.receiveData({ origin: "https://widgets.risevision.com", data: JSON.stringify({ testData: "test" }) });
+
+    expect( console.log ).to.have.been.calledWith( "received message with attribute data", { testData: "test" });
+
+    console.log.restore();
+  });
+
+  it( "should not execute on message if origin not from risevision.com", function() {
+    sinon.stub( console, "log" );
+
+    RisePlayerConfiguration.Preview.receiveData({ origin: "https://test.com", data: JSON.stringify({ testData: "test" }) });
+
+    expect( console.log ).to.not.have.been.called;
+
+    console.log.restore();
+  });
+
+});


### PR DESCRIPTION
- Ensuring to catch the `getRisePlayerConfiguration` function not being injected and restricted reference to `window.top`
- No longer throw error if no configuration was provided as this will be the case for Editor Preview
- Listening for `window.postMessage` messages and ensuring origin is from _risevision.com_
- Future PR will follow up on applying the attribute data to components