### PR TITLE
Apply attribute data to components for template running in Preview

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,8 @@
       "src/rise-logger.js",
       "src/rise-local-storage.js",
       "src/rise-watch.js",
-      "src/rise-preview.js"
+      "src/rise-preview.js",
+      "src/rise-attribute-data.js"
     ];
 
   gulp.task( "clean", function( cb ) {

--- a/src/rise-attribute-data.js
+++ b/src/rise-attribute-data.js
@@ -1,0 +1,108 @@
+/* eslint-disable no-console, one-var */
+
+RisePlayerConfiguration.AttributeData = (() => {
+
+  const LOGGER_DATA = {
+    name: "RisePlayerConfiguration",
+    id: "AttributeData",
+    version: "N/A"
+  };
+
+  let _startEventSent = false;
+
+  function _elementForId( id ) {
+    const elements = RisePlayerConfiguration.Helpers.getRiseEditableElements(),
+      filtered = elements.filter( element => element.id === id );
+
+    return filtered.length === 0 ? null : filtered[ 0 ];
+  }
+
+  function _reset() {
+    _startEventSent = false;
+  }
+
+  function _setProperty( element, property, value ) {
+    const componentId = element.id;
+
+    console.log( `Setting property '${
+      property
+    }' of component ${
+      componentId
+    } to value: '${
+      JSON.stringify( value )
+    }'` );
+
+    try {
+      element[ property ] = value;
+    } catch ( error ) {
+      RisePlayerConfiguration.Logger.error(
+        LOGGER_DATA,
+        "write component property error",
+        {
+          componentId: componentId,
+          property: property,
+          value: value,
+          error: error.stack
+        }
+      );
+    }
+  }
+
+  function _updateComponentsProperties( data ) {
+    const components = data.components || [];
+
+    components.forEach( component => {
+      const keys = Object.keys( component ).filter( key => key !== "id" );
+
+      if ( keys.length === 0 ) {
+        return;
+      }
+
+      const id = component.id;
+      const element = _elementForId( id );
+
+      if ( !element ) {
+        return RisePlayerConfiguration.Logger.warning(
+          LOGGER_DATA,
+          "component not found for id in attribute data",
+          { componentId: id }
+        );
+      }
+
+      keys.forEach( key => _setProperty( element, key, component[ key ]));
+    });
+  }
+
+  function sendStartEvent() {
+    if ( !_startEventSent ) {
+      RisePlayerConfiguration.Helpers.getRiseEditableElements()
+        .forEach( component =>
+          RisePlayerConfiguration.Helpers.sendStartEvent( component )
+        );
+
+      _startEventSent = true;
+    }
+
+    return Promise.resolve();
+  }
+
+  function update( data ) {
+    _updateComponentsProperties( data );
+
+    return sendStartEvent();
+  }
+
+  const exposedFunctions = {
+    sendStartEvent: sendStartEvent,
+    update: update
+  };
+
+  if ( RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+    Object.assign( exposedFunctions, {
+      reset: _reset
+    });
+  }
+
+  return exposedFunctions;
+
+})();

--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -216,7 +216,7 @@ RisePlayerConfiguration.Logger = (() => {
 
     const entry = _createLogEntryFor( componentData, params );
 
-    if ( !_bigQueryLoggingEnabled ) {
+    if ( !_bigQueryLoggingEnabled && params.level !== "info" ) {
       return console.log( JSON.stringify( entry ));
     }
 

--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -40,7 +40,7 @@ RisePlayerConfiguration.Logger = (() => {
 
   function configure() {
     const playerInfo = RisePlayerConfiguration.getPlayerInfo();
-    const rolloutStage = playerInfo.playerType;
+    const rolloutStage = playerInfo && playerInfo.playerType;
 
     if ( RisePlayerConfiguration.isPreview() ||
       ( rolloutStage !== "beta" && rolloutStage !== "stable" )) {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,4 +1,4 @@
-/* eslint-disable one-var */
+/* eslint-disable no-console, one-var */
 
 const RisePlayerConfiguration = {
   RISE_PLAYER_CONFIGURATION_DATA: {
@@ -21,6 +21,8 @@ const RisePlayerConfiguration = {
           throw new Error( `The configuration object is not valid: ${ JSON.stringify( configuration ) }` );
         }
       }
+    } else {
+      console.log( "player configuration not present, running in Preview mode" );
     }
 
     RisePlayerConfiguration.getPlayerInfo = () => playerInfo;

--- a/src/rise-preview.js
+++ b/src/rise-preview.js
@@ -9,9 +9,7 @@ RisePlayerConfiguration.Preview = (() => {
 
     const data = JSON.parse( event.data );
 
-    console.log( "received message with attribute data", data );
-
-    // TODO: apply data to components
+    RisePlayerConfiguration.AttributeData.update( data );
   }
 
   function startListeningForData() {

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -9,8 +9,6 @@ RisePlayerConfiguration.Watch = (() => {
     version: "N/A"
   };
 
-  var _startEventSent = false;
-
   function watchAttributeDataFile() {
     const companyId = RisePlayerConfiguration.getCompanyId();
     const presentationId = RisePlayerConfiguration.getPresentationId();
@@ -23,7 +21,7 @@ RisePlayerConfiguration.Watch = (() => {
         "Can't send attribute data file watch"
       );
 
-      return _sendStartEvent();
+      return RisePlayerConfiguration.AttributeData.sendStartEvent();
     }
 
     // No need to get attribute data or sending start if there are no editable elements.
@@ -58,7 +56,7 @@ RisePlayerConfiguration.Watch = (() => {
 
     case "NOEXIST":
     case "DELETED":
-      return _sendStartEvent();
+      return RisePlayerConfiguration.AttributeData.sendStartEvent();
     }
 
     return Promise.resolve();
@@ -69,16 +67,14 @@ RisePlayerConfiguration.Watch = (() => {
       WATCH_COMPONENT_DATA, "attribute data file error", message
     );
 
-    return _sendStartEvent();
+    return RisePlayerConfiguration.AttributeData.sendStartEvent();
   }
 
   function _handleAttributeDataFileAvailable( fileUrl ) {
 
     return RisePlayerConfiguration.Helpers.getLocalMessagingJsonContent( fileUrl )
       .then( data => {
-        _updateComponentsProperties( data );
-
-        return _sendStartEvent();
+        return RisePlayerConfiguration.AttributeData.update( data );
       })
       .catch( error => {
         RisePlayerConfiguration.Logger.error(
@@ -87,90 +83,13 @@ RisePlayerConfiguration.Watch = (() => {
       });
   }
 
-  function _updateComponentsProperties( data ) {
-    const components = data.components || [];
-
-    components.forEach( component => {
-      const keys = Object.keys( component ).filter( key => key !== "id" );
-
-      if ( keys.length === 0 ) {
-        return;
-      }
-
-      const id = component.id;
-      const element = _elementForId( id );
-
-      if ( !element ) {
-        return RisePlayerConfiguration.Logger.warning(
-          WATCH_COMPONENT_DATA,
-          "component not found for id in attribute data",
-          { componentId: id }
-        );
-      }
-
-      keys.forEach( key => _setProperty( element, key, component[ key ]));
-    });
-  }
-
-  function _elementForId( id ) {
-    const elements = RisePlayerConfiguration.Helpers.getRiseEditableElements();
-    const filtered = elements.filter( element => element.id === id );
-
-    return filtered.length === 0 ? null : filtered[ 0 ];
-  }
-
-  function _setProperty( element, property, value ) {
-    const componentId = element.id;
-
-    console.log( `Setting property '${
-      property
-    }' of component ${
-      componentId
-    } to value: '${
-      JSON.stringify( value )
-    }'` );
-
-    try {
-      element[ property ] = value;
-    } catch ( error ) {
-      RisePlayerConfiguration.Logger.error(
-        WATCH_COMPONENT_DATA,
-        "write component property error",
-        {
-          componentId: componentId,
-          property: property,
-          value: value,
-          error: error.stack
-        }
-      );
-    }
-  }
-
-  function _sendStartEvent() {
-    if ( !_startEventSent ) {
-      RisePlayerConfiguration.Helpers.getRiseEditableElements()
-        .forEach( component =>
-          RisePlayerConfiguration.Helpers.sendStartEvent( component )
-        );
-
-      _startEventSent = true;
-    }
-
-    return Promise.resolve();
-  }
-
-  function _reset() {
-    _startEventSent = false;
-  }
-
   const exposedFunctions = {
     watchAttributeDataFile: watchAttributeDataFile
   };
 
   if ( RisePlayerConfiguration.Helpers.isTestEnvironment()) {
     Object.assign( exposedFunctions, {
-      handleAttributeDataFileUpdateMessage: _handleAttributeDataFileUpdateMessage,
-      reset: _reset
+      handleAttributeDataFileUpdateMessage: _handleAttributeDataFileUpdateMessage
     });
   }
 

--- a/test/unit/rise-attribute-data.test.js
+++ b/test/unit/rise-attribute-data.test.js
@@ -1,0 +1,83 @@
+/* global afterEach, beforeEach, describe, it, expect, sinon */
+/* eslint-disable vars-on-top */
+
+"use strict";
+
+describe( "AttributeData", function() {
+
+  var editableElements;
+
+  beforeEach( function() {
+
+    editableElements = [
+      { id: "rise-data-image-01" },
+      { id: "rise-data-financial-01" }
+    ];
+
+    sinon.stub( RisePlayerConfiguration.Helpers, "getRiseEditableElements", function() {
+      return editableElements;
+    });
+
+    sinon.stub( RisePlayerConfiguration.Helpers, "sendStartEvent" );
+  });
+
+  afterEach( function() {
+    RisePlayerConfiguration.Helpers.getRiseEditableElements.restore();
+    RisePlayerConfiguration.Helpers.sendStartEvent.restore();
+  });
+
+  describe( "update", function() {
+
+    afterEach( function() {
+      RisePlayerConfiguration.AttributeData.reset();
+    });
+
+    it( "should update attribute data on all editable elements", function() {
+
+      return RisePlayerConfiguration.AttributeData.update({
+        components: [
+          {
+            id: "rise-data-financial-01",
+            symbols: "AAPL.O|AMZN.O|FB.O|GOOGL.O"
+          }
+        ]
+      })
+        .then( function() {
+          expect( RisePlayerConfiguration.Helpers.getRiseEditableElements.called ).to.be.true;
+          expect( RisePlayerConfiguration.Helpers.sendStartEvent.called ).to.be.true;
+
+          expect( editableElements ).to.deep.equal([
+            {
+              id: "rise-data-image-01"
+            },
+            {
+              id: "rise-data-financial-01",
+              symbols: "AAPL.O|AMZN.O|FB.O|GOOGL.O"
+            }
+          ]);
+        });
+
+    });
+
+  });
+
+  describe( "sendStartEvent", function() {
+
+    it( "should send start event to components when never been sent before", function() {
+      return RisePlayerConfiguration.AttributeData.sendStartEvent()
+        .then( function() {
+          expect( RisePlayerConfiguration.Helpers.sendStartEvent.called ).to.be.true;
+        });
+
+    });
+
+    it( "should not send start event to components when already been sent", function() {
+      return RisePlayerConfiguration.AttributeData.sendStartEvent()
+        .then( function() {
+          expect( RisePlayerConfiguration.Helpers.sendStartEvent.called ).to.be.false;
+        });
+    });
+
+  });
+
+});

--- a/test/unit/rise-preview.test.js
+++ b/test/unit/rise-preview.test.js
@@ -1,28 +1,30 @@
-/* global describe, it, sinon, expect */
+/* global describe, it, sinon, expect, beforeEach, afterEach */
 /* eslint-disable no-console */
 
 "use strict";
 
 describe( "Preview", function() {
 
-  it( "should receive data from a 'message'", function() {
-    sinon.stub( console, "log" );
+  var updateStub;
 
+  beforeEach( function() {
+    updateStub = sinon.stub( RisePlayerConfiguration.AttributeData, "update" );
+  });
+
+  afterEach( function() {
+    updateStub.restore();
+  });
+
+  it( "should receive data from a 'message'", function() {
     RisePlayerConfiguration.Preview.receiveData({ origin: "https://widgets.risevision.com", data: JSON.stringify({ testData: "test" }) });
 
-    expect( console.log ).to.have.been.calledWith( "received message with attribute data", { testData: "test" });
-
-    console.log.restore();
+    expect( updateStub ).to.have.been.calledWith({ testData: "test" });
   });
 
   it( "should not execute on message if origin not from risevision.com", function() {
-    sinon.stub( console, "log" );
-
     RisePlayerConfiguration.Preview.receiveData({ origin: "https://test.com", data: JSON.stringify({ testData: "test" }) });
 
-    expect( console.log ).to.not.have.been.called;
-
-    console.log.restore();
+    expect( updateStub ).to.not.have.been.called;
   });
 
 });


### PR DESCRIPTION
- Refactored `rise-watch.js` to extract updating component properties and sending start events to a separate `rise-attribute.js` so both _watch_ and _preview_ can leverage as they require the same process for updating components. (as discussed and agreed on [Editor Preview design](https://docs.google.com/document/d/1XTtxPMTi-FzQUy_7wolug5P4XQ5daQQ4shr-hGK7HZg/edit?ts=5c9387cf)

I will be testing with a staged version of common-template in a production HTML template that Mat/Peter have just created (no users using it). I will report how it goes on this PR once validated, please review in the meantime. 