### PR TITLE
Handle rise-play-until-done element as PUD regardless of attribute state

### DIFF
--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -17,7 +17,7 @@ RisePlayerConfiguration.PlayUntilDone = (() => {
 
   function start() {
     const riseElements = RisePlayerConfiguration.Helpers.getRiseElements();
-    const playUntilDoneElements = riseElements.filter( element => element.hasAttribute( "play-until-done" ));
+    const playUntilDoneElements = riseElements.filter( element => element.hasAttribute( "play-until-done" ) || element.tagName.toLowerCase() === "rise-play-until-done" );
 
     console.log( `Start listening PUD events of ${playUntilDoneElements.length} elements` );
     RisePlayerConfiguration.Logger.info( LOGGER_DATA, "start listening PUD events", { playUntilDoneElements: playUntilDoneElements.length });

--- a/test/unit/rise-play-until-done.test.js
+++ b/test/unit/rise-play-until-done.test.js
@@ -18,6 +18,7 @@ describe( "PlayUntilDone", function() {
       "rise-image-1": { id: "rise-image-1", tagName: "rise-image", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() },
       "rise-image-2": { id: "rise-image-2", tagName: "rise-image", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() },
       "rise-text-1": { id: "rise-text-1", tagName: "rise-text", hasAttribute: function() { return false; }, addEventListener: sandbox.stub() },
+      "rise-play-until-done-1": { id: "rise-play-until-done-1", tagName: "rise-play-until-done", hasAttribute: function() { return false; }, addEventListener: sandbox.stub() }
     };
 
     sandbox.stub( RisePlayerConfiguration.Helpers, "getRiseElements", function() {
@@ -36,6 +37,7 @@ describe( "PlayUntilDone", function() {
 
       expectedComponents[ "rise-image-1" ].addEventListener.should.have.been.calledWith( "report-done" );
       expectedComponents[ "rise-image-2" ].addEventListener.should.have.been.calledWith( "report-done" );
+      expectedComponents[ "rise-play-until-done-1" ].addEventListener.should.have.been.calledWith( "report-done" );
       expectedComponents[ "rise-text-1" ].addEventListener.should.not.have.been.calledWith( "report-done" );
     });
 
@@ -60,6 +62,7 @@ describe( "PlayUntilDone", function() {
 
       expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
       expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: true } });
+      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: true } });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 
@@ -72,6 +75,7 @@ describe( "PlayUntilDone", function() {
 
       expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
       expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: false } });
+      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: false } });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 


### PR DESCRIPTION
- The play-until-done attribute only gets set after Polymer finished installed every component. This causes the report-done event handler to not be set up. This change fixes it by installing the event handler for every rise-play-until done element.