### PR TITLE
Feature/send extracted data to bq

### DIFF
--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -49,7 +49,7 @@ RisePlayerConfiguration.Watch = (() => {
         RisePlayerConfiguration.Logger.error(
           WATCH_DATA_FILE, "data file read error", {
             message: message,
-            stack: error.stack
+            stack: error.stack || error
           }
         );
       });

--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -40,15 +40,19 @@ RisePlayerConfiguration.Watch = (() => {
 
   function _handleFileAvailable( message, handlerSuccess ) {
     var fileUrl = message.fileUrl;
+    var extractedData;
 
     return RisePlayerConfiguration.Helpers.getLocalMessagingJsonContent( fileUrl )
       .then( data => {
+        extractedData = data;
+
         return handlerSuccess( data );
       })
       .catch( error => {
         RisePlayerConfiguration.Logger.error(
           WATCH_DATA_FILE, "data file read error", {
             message: message,
+            data: extractedData,
             stack: error.stack || error
           }
         );


### PR DESCRIPTION
## Description
This is intended to help gather more data around 'data file read error' entries.

I'm adding the extracted data ( if available ) to the BQ entry, and also print the full error if there is no stack available ( as it's happening ).

## Motivation and Context
Right now we are receiving the RLS message that's causing the error, but we still need more context to determine what's going wrong.

## How Has This Been Tested?
I manually tested the changes using a staged version of a template that uses this component in this schedule:
https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - Manual testing above
    - Release before Friday
    - Release plan: will immediately check it working OK after deploying
    - Simple rollback will correct it, but any affected display would require restart. I consider it to be a low risk change, though.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No automated test changes needed.
No documentation update needed.
No need to notify support.
