### PR TITLE
send rise-presentation-play event on preview

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -141,10 +141,13 @@ const RisePlayerConfiguration = {
   isPreview: function() {
     return RisePlayerConfiguration.getDisplayId() === "preview";
   },
+  dispatchWindowEvent( name ) {
+    window.dispatchEvent( new CustomEvent( name ));
+  },
   sendComponentsReadyEvent() {
-    Promise.resolve()
+    return Promise.resolve()
       .then(() => {
-        window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
+        RisePlayerConfiguration.dispatchWindowEvent( "rise-components-ready" );
 
         if ( !RisePlayerConfiguration.isPreview()) {
           RisePlayerConfiguration.Logger.info(
@@ -154,6 +157,7 @@ const RisePlayerConfiguration = {
 
           RisePlayerConfiguration.AttributeDataWatch.watchAttributeDataFile();
         } else {
+          RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
           RisePlayerConfiguration.Preview.startListeningForData();
         }
       });


### PR DESCRIPTION
## Description
Fix for 1187 https://github.com/Rise-Vision/rise-vision-apps/issues/1187

## Motivation and Context
common-template check if it's in preview, and in that case it sends "rise-presentation-play" event, so templates can listen to it.

Other minor changes were done to the code to facilitate testing.

## How Has This Been Tested?
A slightly modified version of qa-image-template was created that points to the staged component and has this code:

console.log( "adding presentation play" );
window.addEventListener( "rise-presentation-play", () => {
  console.log( "presentation play" );
});

When run in player, the 'presentation play' text is not executed; but it is when run in preview:

![console](https://user-images.githubusercontent.com/33162690/63453316-0260df00-c40e-11e9-8808-3e5f0eca1e0c.png)

This can be validated here:

https://apps.risevision.com/templates/edit/0ada0513-d383-4578-b30c-fc9505b8e636/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

A schedule with player here:

https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - Manual testing described above
    - Automated tests created as part of the PR
    - To deploy before Friday
    - Release strategy: will test immediately after releasing; simple rollback is needed if something goes wrong.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No documentation updates are necessary.
No need to notify support.

FYI @pcsandford 
