### PR TITLE
Fix/is preview cant be called before configure

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -3,10 +3,6 @@
 const RisePlayerConfiguration = (() => {
 
   function _init( playerInfo, localMessagingInfo ) {
-    if ( RisePlayerConfiguration.getPlayerInfo ) {
-      return;
-    }
-
     if ( !playerInfo && !localMessagingInfo ) {
       // outside of viewer or inside of viewer
       const getConfiguration = RisePlayerConfiguration.Helpers.getRisePlayerConfiguration();
@@ -25,7 +21,9 @@ const RisePlayerConfiguration = (() => {
       console.log( "player configuration not present, running in Preview mode" );
     }
 
-    RisePlayerConfiguration.getPlayerInfo = () => playerInfo;
+    if ( !RisePlayerConfiguration.getPlayerInfo ) {
+      RisePlayerConfiguration.getPlayerInfo = () => playerInfo;
+    }
 
     return localMessagingInfo;
   }

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console, one-var */
 
-const RisePlayerConfiguration = {
-  RISE_PLAYER_CONFIGURATION_DATA: {
-    name: "RisePlayerConfiguration",
-    id: "RisePlayerConfiguration",
-    version: "N/A"
-  },
-  configure: ( playerInfo, localMessagingInfo ) => {
+const RisePlayerConfiguration = (() => {
+
+  function _init( playerInfo, localMessagingInfo ) {
+    if ( RisePlayerConfiguration.getPlayerInfo ) {
+      return;
+    }
+
     if ( !playerInfo && !localMessagingInfo ) {
       // outside of viewer or inside of viewer
       const getConfiguration = RisePlayerConfiguration.Helpers.getRisePlayerConfiguration();
@@ -27,6 +27,10 @@ const RisePlayerConfiguration = {
 
     RisePlayerConfiguration.getPlayerInfo = () => playerInfo;
 
+    return localMessagingInfo;
+  }
+
+  function _validateAllRequiredObjectsAreAvailable() {
     if ( !RisePlayerConfiguration.LocalMessaging ) {
       throw new Error( "RiseLocalMessaging script was not loaded" );
     }
@@ -66,104 +70,117 @@ const RisePlayerConfiguration = {
     if ( !RisePlayerConfiguration.ContentUptime ) {
       throw new Error( "ContentUptime script was not loaded" );
     }
+  }
 
-    RisePlayerConfiguration.Logger.configure();
+  return {
+    RISE_PLAYER_CONFIGURATION_DATA: {
+      name: "RisePlayerConfiguration",
+      id: "RisePlayerConfiguration",
+      version: "N/A"
+    },
+    configure: ( playerInfo, localMessagingInfo ) => {
+      localMessagingInfo = _init( playerInfo, localMessagingInfo );
 
-    if ( RisePlayerConfiguration.isPreview()) {
-      RisePlayerConfiguration.sendComponentsReadyEvent();
-    } else {
-      if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
-        const handler = ( event ) => {
-          if ( event.detail.isConnected ) {
-            window.removeEventListener( "rise-local-messaging-connection", handler );
+      _validateAllRequiredObjectsAreAvailable();
 
-            RisePlayerConfiguration.sendComponentsReadyEvent();
-          }
-        };
+      RisePlayerConfiguration.Logger.configure();
 
-        window.addEventListener( "rise-local-messaging-connection", handler );
+      if ( RisePlayerConfiguration.isPreview()) {
+        RisePlayerConfiguration.sendComponentsReadyEvent();
+      } else {
+        if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+          const handler = ( event ) => {
+            if ( event.detail.isConnected ) {
+              window.removeEventListener( "rise-local-messaging-connection", handler );
+
+              RisePlayerConfiguration.sendComponentsReadyEvent();
+            }
+          };
+
+          window.addEventListener( "rise-local-messaging-connection", handler );
+        }
+
+        RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
       }
 
-      RisePlayerConfiguration.LocalMessaging.configure( localMessagingInfo );
-    }
+      if ( RisePlayerConfiguration.Helpers.isInViewer()) {
+        RisePlayerConfiguration.Viewer.startListeningForData();
+      }
 
-    if ( RisePlayerConfiguration.Helpers.isInViewer()) {
-      RisePlayerConfiguration.Viewer.startListeningForData();
-    }
+      // lock down RisePlayerConfiguration object
+      if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+        Object.freeze( RisePlayerConfiguration );
+      }
+    },
+    isConfigured() {
+      return !!RisePlayerConfiguration.getPlayerInfo;
+    },
+    getChromeVersion: function() {
+      const info = RisePlayerConfiguration.getPlayerInfo();
 
-    // lock down RisePlayerConfiguration object
-    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
-      Object.freeze( RisePlayerConfiguration );
-    }
-  },
-  isConfigured() {
-    return !!RisePlayerConfiguration.getPlayerInfo;
-  },
-  getChromeVersion: function() {
-    const info = RisePlayerConfiguration.getPlayerInfo();
+      if ( info && info.chromeVersion ) {
+        return info.chromeVersion;
+      }
 
-    if ( info && info.chromeVersion ) {
-      return info.chromeVersion;
-    }
+      const match = navigator.userAgent.match( /Chrom(e|ium)\/([0-9.]+)/ );
 
-    const match = navigator.userAgent.match( /Chrom(e|ium)\/([0-9.]+)/ );
+      return match ? match[ 2 ] : null;
+    },
+    getCompanyId: function() {
+      var playerInfo = RisePlayerConfiguration.getPlayerInfo();
 
-    return match ? match[ 2 ] : null;
-  },
-  getCompanyId: function() {
-    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+      return playerInfo ? playerInfo.companyId : null;
+    },
+    getDisplayId: function() {
+      var playerInfo = RisePlayerConfiguration.getPlayerInfo();
 
-    return playerInfo ? playerInfo.companyId : null;
-  },
-  getDisplayId: function() {
-    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+      return playerInfo ? playerInfo.displayId || "preview" : "preview";
+    },
+    getPresentationId: function() {
+      var playerInfo = RisePlayerConfiguration.getPlayerInfo();
 
-    return playerInfo ? playerInfo.displayId || "preview" : "preview";
-  },
-  getPresentationId: function() {
-    var playerInfo = RisePlayerConfiguration.getPlayerInfo();
+      if ( playerInfo && playerInfo.presentationId ) {
+        return playerInfo.presentationId;
+      }
 
-    if ( playerInfo && playerInfo.presentationId ) {
-      return playerInfo.presentationId;
-    }
+      return RisePlayerConfiguration.Helpers.getHttpParameter( "presentationId" );
+    },
+    getTemplateProductCode() {
+      return window.TEMPLATE_PRODUCT_CODE ? window.TEMPLATE_PRODUCT_CODE : "";
+    },
+    getTemplateVersion() {
+      return window.TEMPLATE_VERSION ? window.TEMPLATE_VERSION : "";
+    },
+    getTemplateName() {
+      return window.TEMPLATE_NAME ? window.TEMPLATE_NAME : "";
+    },
+    isPreview: function() {
+      return RisePlayerConfiguration.getDisplayId() === "preview";
+    },
+    dispatchWindowEvent( name ) {
+      window.dispatchEvent( new CustomEvent( name ));
+    },
+    sendComponentsReadyEvent() {
+      return Promise.resolve()
+        .then(() => {
+          RisePlayerConfiguration.dispatchWindowEvent( "rise-components-ready" );
 
-    return RisePlayerConfiguration.Helpers.getHttpParameter( "presentationId" );
-  },
-  getTemplateProductCode() {
-    return window.TEMPLATE_PRODUCT_CODE ? window.TEMPLATE_PRODUCT_CODE : "";
-  },
-  getTemplateVersion() {
-    return window.TEMPLATE_VERSION ? window.TEMPLATE_VERSION : "";
-  },
-  getTemplateName() {
-    return window.TEMPLATE_NAME ? window.TEMPLATE_NAME : "";
-  },
-  isPreview: function() {
-    return RisePlayerConfiguration.getDisplayId() === "preview";
-  },
-  dispatchWindowEvent( name ) {
-    window.dispatchEvent( new CustomEvent( name ));
-  },
-  sendComponentsReadyEvent() {
-    return Promise.resolve()
-      .then(() => {
-        RisePlayerConfiguration.dispatchWindowEvent( "rise-components-ready" );
+          if ( !RisePlayerConfiguration.isPreview()) {
+            RisePlayerConfiguration.Logger.info(
+              RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA,
+              "rise-components-ready"
+            );
 
-        if ( !RisePlayerConfiguration.isPreview()) {
-          RisePlayerConfiguration.Logger.info(
-            RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA,
-            "rise-components-ready"
-          );
-
-          RisePlayerConfiguration.AttributeDataWatch.watchAttributeDataFile();
-        } else {
-          RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
-          RisePlayerConfiguration.Preview.startListeningForData();
-        }
-      });
-  },
-  Helpers: null,
-  LocalMessaging: null,
-  LocalStorage: null,
-  Logger: null
-};
+            RisePlayerConfiguration.AttributeDataWatch.watchAttributeDataFile();
+          } else {
+            RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
+            RisePlayerConfiguration.Preview.startListeningForData();
+          }
+        });
+    },
+    Helpers: null,
+    LocalMessaging: null,
+    LocalStorage: null,
+    Logger: null
+  };
+})();

--- a/test/unit/rise-logger/big-query.test.js
+++ b/test/unit/rise-logger/big-query.test.js
@@ -29,7 +29,12 @@ describe( "Big Query logging", function() {
     INTERVAL = 3580000,
     clock;
 
+  beforeEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
+  });
+
   afterEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
   });
 

--- a/test/unit/rise-logger/configuration.test.js
+++ b/test/unit/rise-logger/configuration.test.js
@@ -5,7 +5,12 @@
 
 describe( "configure", function() {
 
+  beforeEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
+  });
+
   afterEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
   });
 

--- a/test/unit/rise-logger/log-entry.test.js
+++ b/test/unit/rise-logger/log-entry.test.js
@@ -11,7 +11,12 @@ describe( "log-entry", function() {
     "version": "2018.01.01.10.00"
   };
 
+  beforeEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
+  });
+
   afterEach( function() {
+    RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
   });
 

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -44,10 +44,6 @@ describe( "RisePlayerConfiguration", function() {
 
   describe( "isConfigured", function() {
 
-    beforeEach( function() {
-      RisePlayerConfiguration.getPlayerInfo = undefined;
-    });
-
     it( "should not be configured if configure() function has not been called", function() {
       expect( RisePlayerConfiguration.isConfigured()).to.be.false;
     });
@@ -74,6 +70,39 @@ describe( "RisePlayerConfiguration", function() {
 
   describe( "getDisplayId", function() {
 
+    afterEach( function() {
+      window.getRisePlayerConfiguration = undefined;
+    });
+
+    it( "should be able to call getDisplayId even if it's not configured", function() {
+      expect( RisePlayerConfiguration.getDisplayId()).to.equal( "preview" );
+    });
+
+    it( "should get the display id even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            displayId: "ABC",
+            companyId: "123"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.equal( "ABC" );
+    });
+
+    it( "should detect is preview when it's not configured and player info has no display id", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {},
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getDisplayId()).to.equal( "preview" );
+    });
+
     it( "should return the display id", function() {
       RisePlayerConfiguration.configure({ displayId: "id" });
 
@@ -90,6 +119,39 @@ describe( "RisePlayerConfiguration", function() {
 
   describe( "getCompanyId", function() {
 
+    afterEach( function() {
+      window.getRisePlayerConfiguration = undefined;
+    });
+
+    it( "should be able to call getCompanyId even if it's not configured", function() {
+      expect( RisePlayerConfiguration.getCompanyId()).to.be.null;
+    });
+
+    it( "should get the display id even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            displayId: "ABC",
+            companyId: "123"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getCompanyId()).to.equal( "123" );
+    });
+
+    it( "should not return company id when it's not configured and player info has no company id", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {},
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getCompanyId()).to.be.falsey;
+    });
+
     it( "should return the company id", function() {
       RisePlayerConfiguration.configure({ companyId: "id" });
 
@@ -105,6 +167,39 @@ describe( "RisePlayerConfiguration", function() {
   });
 
   describe( "getPresentationId", function() {
+
+    afterEach( function() {
+      window.getRisePlayerConfiguration = undefined;
+    });
+
+    it( "should be able to call getPresentationId even if it's not configured", function() {
+      RisePlayerConfiguration.Helpers.getHttpParameter = function() {
+        return null;
+      }
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.be.null;
+    });
+
+    it( "should get the presentation id form an HTTP param even if it's not configured", function() {
+      RisePlayerConfiguration.Helpers.getHttpParameter = function() {
+        return "id";
+      }
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.equal( "id" );
+    });
+
+    it( "should get the presentation id even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            presentationId: "id"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getPresentationId()).to.equal( "id" );
+    });
 
     it( "should return the presentation id", function() {
       RisePlayerConfiguration.configure({ presentationId: "id" });
@@ -136,6 +231,42 @@ describe( "RisePlayerConfiguration", function() {
 
   describe( "isPreview", function() {
 
+    afterEach( function() {
+      window.getRisePlayerConfiguration = undefined;
+    });
+
+    it( "should be able to call preview even if it's not configured", function() {
+      expect( RisePlayerConfiguration.isPreview()).to.be.true;
+    });
+
+    it( "should detect it's preview even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            displayId: "preview",
+            companyId: "123"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.isPreview()).to.be.true;
+    });
+
+    it( "should detect it's not preview even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            displayId: "ABC",
+            companyId: "123"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.isPreview()).to.be.false;
+    });
+
     it( "should be preview if display id is 'preview'", function() {
       RisePlayerConfiguration.configure({ displayId: "preview" });
 
@@ -158,6 +289,37 @@ describe( "RisePlayerConfiguration", function() {
       window.addEventListener( "rise-components-ready", connectionHandler );
 
       RisePlayerConfiguration.configure({ displayId: "preview" });
+    });
+
+  });
+
+  describe( "getChromeVersion", function() {
+
+    afterEach( function() {
+      window.getRisePlayerConfiguration = undefined;
+    });
+
+    it( "should be able to call getChromeVersion even if it's not configured", function() {
+      expect( RisePlayerConfiguration.getChromeVersion()).to.be.null;
+    });
+
+    it( "should get the chrome version even if it's not configured", function() {
+      window.getRisePlayerConfiguration = function() {
+        return {
+          playerInfo: {
+            chromeVersion: "1233"
+          },
+          localMessagingInfo: {}
+        }
+      }
+
+      expect( RisePlayerConfiguration.getChromeVersion()).to.equal( "1233" );
+    });
+
+    it( "should return the chrome version", function() {
+      RisePlayerConfiguration.configure({ chromeVersion: "1234" });
+
+      expect( RisePlayerConfiguration.getChromeVersion()).to.equal( "1234" );
     });
 
   });

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -12,6 +12,7 @@ describe( "RisePlayerConfiguration", function() {
   beforeEach( function() {
     _sandbox = sinon.sandbox.create();
 
+    RisePlayerConfiguration.getPlayerInfo = undefined;
     _helpers = RisePlayerConfiguration.Helpers;
     _logger = RisePlayerConfiguration.Logger;
     _localMessaging = RisePlayerConfiguration.LocalMessaging;
@@ -35,6 +36,7 @@ describe( "RisePlayerConfiguration", function() {
   afterEach( function() {
     _sandbox.restore();
 
+    RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Helpers = _helpers;
     RisePlayerConfiguration.Logger = _logger;
     RisePlayerConfiguration.LocalMessaging = _localMessaging;


### PR DESCRIPTION
## Description
Adds support so that getter functions on RisePlayerConfiguration such as isPreview(), getDisplayId(), getCompanyId(), getPresentationId() and getChromeVersion() can be called even if RisePlayerConfiguration.configure() has not been called.

## Motivation and Context
Those functions currently rely on getPlayerInfo() function to be present in RisePlayerConfiguration ( which is set during configure() ). But some templates were relying on isPreview to do their own initialization, and they were reporting null reference errors. 

So this code changes those functions so they directly inspect the player configuration ( as configure() currently does ) when getPlayerInfo function is still not available.

Some refactoring was done to the RisePlayerConfiguration object so common code could be shared with the functions that now needed it ( the new _getConfiguration function ). Also, configure() was separated into smaller pieces as it has grown large and difficult to read. 

NOTE: because indentation changed, the github diff for rise-player-configuration.js is a mess; maybe it's better to review the full file instead. No behavior was changed on current functionality other than what I mentioned above.

This problem was encountered when solving: https://github.com/Rise-Vision/rise-vision-apps/issues/1187

## How Has This Been Tested?
A slightly modified version of qa-image-component that uses this library was pushed to stable, with the following code:

```
console.log( "adding presentation play" );
console.log( RisePlayerConfiguration.isPreview());
window.addEventListener( "rise-presentation-play", () => {
  console.log( "presentation play" );
});
```

This detects preview before the configure() call without errors if it is run in a presentation such as this one:
https://apps.risevision.com/templates/edit/0ada0513-d383-4578-b30c-fc9505b8e636/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

And detects it's not preview without errors also if it's run in this schedule:
https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Also, several unit tests were added to each of the methods referenced above to ensure they work well when no configure() has been called.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be deployed on Thursday or Monday
     - Both manual and automated tests done
     - Release plan, validate immediately after release, and rollback if there are problems.
     - No data affected, simple rollback is necessary.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No documentation changes necessary
No need to notify support

FYI @pcsandford 
