### PR TITLE
Fix timing issue when template loads before player injects its code

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -95,6 +95,10 @@ RisePlayerConfiguration.Helpers = (() => {
     return configuration;
   }
 
+  function getWaitForPlayerURLParam() {
+    return getHttpParameter( "waitForPlayer" ) === "true";
+  }
+
   function getLocalMessagingTextContent( fileUrl ) {
     return new Promise(( resolve, reject ) => {
       const xhr = new XMLHttpRequest();
@@ -151,6 +155,7 @@ RisePlayerConfiguration.Helpers = (() => {
     getRiseElements: getRiseElements,
     getRiseEditableElements: getRiseEditableElements,
     getRisePlayerConfiguration: getRisePlayerConfiguration,
+    getWaitForPlayerURLParam: getWaitForPlayerURLParam,
     isTestEnvironment: isTestEnvironment,
     isInViewer: isInViewer,
     onceClientsAreAvailable: onceClientsAreAvailable,

--- a/src/rise-local-messaging.js
+++ b/src/rise-local-messaging.js
@@ -9,6 +9,7 @@ RisePlayerConfiguration.LocalMessaging = (() => {
     _clientName,
     _connection,
     _connectionType,
+    _initialWindowConnectionTimer,
     _playerType,
     _initialWebsocketConnectionTimer = null,
     _messageHandlers = [],
@@ -143,8 +144,21 @@ RisePlayerConfiguration.LocalMessaging = (() => {
   }
 
   function _initWindowConnection() {
-    _connected = _isWindowConnectionAvailable();
-    _sendConnectionEvent();
+    if ( _isWindowConnectionAvailable()) {
+      _receiveWindowMessages( message => {
+        if ( _connected ) {
+          return;
+        }
+
+        _connected = message.topic.toUpperCase() === "CLIENT-LIST";
+        _sendConnectionEvent();
+
+        clearTimeout( _initialWindowConnectionTimer );
+      });
+
+      _broadcastWindowMessage({ topic: "client-list-request" });
+    }
+    _initialWindowConnectionTimer = setTimeout( _initWindowConnection, 100 );
   }
 
   function _receiveWebsocketMessages( handler ) {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -114,35 +114,44 @@ const RisePlayerConfiguration = (() => {
     Object.freeze( RisePlayerConfiguration );
   }
 
+  function configure( playerInfo, localMessagingInfo ) {
+    _validateAllRequiredObjectsAreAvailable();
+
+    const configuration = _getPlayerConfiguration();
+
+    if ( !configuration && RisePlayerConfiguration.Helpers.getWaitForPlayerURLParam()) {
+      setTimeout(() => configure( playerInfo, localMessagingInfo ), 100 );
+      return;
+    }
+
+    localMessagingInfo = _init( playerInfo, localMessagingInfo );
+
+    RisePlayerConfiguration.Logger.configure();
+
+    if ( RisePlayerConfiguration.isPreview()) {
+      RisePlayerConfiguration.sendComponentsReadyEvent();
+    } else {
+      _configureLocalMessaging( localMessagingInfo );
+    }
+
+    if ( RisePlayerConfiguration.Helpers.isInViewer()) {
+      RisePlayerConfiguration.Viewer.startListeningForData();
+    } else {
+      _sendRisePresentationPlayOnDocumentLoad();
+    }
+
+    if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
+      _lockDownRisePlayerConfiguration();
+    }
+  }
+
   return {
     RISE_PLAYER_CONFIGURATION_DATA: {
       name: "RisePlayerConfiguration",
       id: "RisePlayerConfiguration",
       version: "N/A"
     },
-    configure: ( playerInfo, localMessagingInfo ) => {
-      _validateAllRequiredObjectsAreAvailable();
-
-      localMessagingInfo = _init( playerInfo, localMessagingInfo );
-
-      RisePlayerConfiguration.Logger.configure();
-
-      if ( RisePlayerConfiguration.isPreview()) {
-        RisePlayerConfiguration.sendComponentsReadyEvent();
-      } else {
-        _configureLocalMessaging( localMessagingInfo );
-      }
-
-      if ( RisePlayerConfiguration.Helpers.isInViewer()) {
-        RisePlayerConfiguration.Viewer.startListeningForData();
-      } else {
-        _sendRisePresentationPlayOnDocumentLoad();
-      }
-
-      if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
-        _lockDownRisePlayerConfiguration();
-      }
-    },
+    configure: configure,
     isConfigured() {
       return !!RisePlayerConfiguration.getPlayerInfo;
     },

--- a/test/unit/rise-logger/big-query.test.js
+++ b/test/unit/rise-logger/big-query.test.js
@@ -27,15 +27,21 @@ describe( "Big Query logging", function() {
       }
     },
     INTERVAL = 3580000,
-    clock;
+    clock,
+    sandbox;
 
   beforeEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
+
+    sandbox = sinon.sandbox.create();
+    sandbox.stub( RisePlayerConfiguration.Helpers, "getWaitForPlayerURLParam" ).returns( false );
   });
 
   afterEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
+
+    sandbox.restore();
   });
 
   describe( "getInsertData", function() {

--- a/test/unit/rise-logger/configuration.test.js
+++ b/test/unit/rise-logger/configuration.test.js
@@ -5,13 +5,20 @@
 
 describe( "configure", function() {
 
+  var sandbox;
+
   beforeEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
+
+    sandbox = sinon.sandbox.create();
+    sandbox.stub( RisePlayerConfiguration.Helpers, "getWaitForPlayerURLParam" ).returns( false );
   });
 
   afterEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
+
+    sandbox.restore();
   });
 
   it( "should not enable BQ logging if no player type is defined", function() {

--- a/test/unit/rise-logger/log-entry.test.js
+++ b/test/unit/rise-logger/log-entry.test.js
@@ -5,19 +5,25 @@
 
 describe( "log-entry", function() {
 
-  var COMPONENT_DATA = {
-    "id": "rise-data-image-01",
-    "name": "rise-data-image",
-    "version": "2018.01.01.10.00"
-  };
+  var sandbox,
+    COMPONENT_DATA = {
+      "id": "rise-data-image-01",
+      "name": "rise-data-image",
+      "version": "2018.01.01.10.00"
+    };
 
   beforeEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
+
+    sandbox = sinon.sandbox.create();
+    sandbox.stub( RisePlayerConfiguration.Helpers, "getWaitForPlayerURLParam" ).returns( false );
   });
 
   afterEach( function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
     RisePlayerConfiguration.Logger.reset();
+
+    sandbox.restore();
   });
 
   describe( "_createLogEntryFor", function() {


### PR DESCRIPTION
## Description
This is part of the fix for defect Rise-Vision/rise-vision-apps#1208. Player related PR is https://github.com/Rise-Vision/chrome-os-player/pull/231

## Motivation and Context

This defect happens on Chrome OS quite frequently because the injected code is not preloaded and happens at the same time the template loads. The fix consists in a change in the player to include a "waitForPlayer" when loading the template URL.

`RisePlayerConfiguration.configure` will retry configuring until the injected code is available if the "waitForPlayer" URL parameter is set.

`RisePlayerConfiguration.LocalMessaging._initWindowConnection` only sends the connected event when player responds and will keep retrying until this happens.

## How Has This Been Tested?
This needs to be tested in conjunction with the changes in player It was tested running player locally and having common-template mapped locally with Charles proxy.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
