### PR TITLE
Send rise-presentation-play when document is loaded

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -105,9 +105,9 @@ const RisePlayerConfiguration = (() => {
   }
 
   function _sendRisePresentationPlayOnDocumentLoad() {
-    window.addEventListener( "DOMContentLoaded", () =>
-      RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" )
-    );
+    window.addEventListener( "DOMContentLoaded", () => {
+      setTimeout(() => RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" ), 100 );
+    });
   }
 
   function _lockDownRisePlayerConfiguration() {
@@ -201,6 +201,8 @@ const RisePlayerConfiguration = (() => {
       return RisePlayerConfiguration.getDisplayId() === "preview";
     },
     dispatchWindowEvent( name ) {
+      console.log( `Dispatching ${name} event` );
+
       window.dispatchEvent( new CustomEvent( name ));
     },
     sendComponentsReadyEvent() {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -106,7 +106,10 @@ const RisePlayerConfiguration = (() => {
 
   function _sendRisePresentationPlayOnDocumentLoad() {
     window.addEventListener( "DOMContentLoaded", () => {
-      setTimeout(() => RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" ), 100 );
+      setTimeout(() => {
+        RisePlayerConfiguration.Logger.info( RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA, "rise-presentation-play" );
+        RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
+      }, 100 );
     });
   }
 

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -105,12 +105,18 @@ const RisePlayerConfiguration = (() => {
   }
 
   function _sendRisePresentationPlayOnDocumentLoad() {
-    window.addEventListener( "DOMContentLoaded", () => {
-      setTimeout(() => {
+    const sendRisePresentationPlay = () => {
+      if ( !RisePlayerConfiguration.Helpers.isTestEnvironment()) {
         RisePlayerConfiguration.Logger.info( RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA, "rise-presentation-play" );
-        RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
-      }, 100 );
-    });
+      }
+      RisePlayerConfiguration.dispatchWindowEvent( "rise-presentation-play" );
+    };
+
+    window.addEventListener( "DOMContentLoaded", sendRisePresentationPlay );
+
+    if ( document.readyState === "complete" || document.readyState === "loaded" || document.readyState === "interactive" ) {
+      sendRisePresentationPlay();
+    }
   }
 
   function _lockDownRisePlayerConfiguration() {

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -37,13 +37,11 @@ RisePlayerConfiguration.Viewer = (() => {
     if ( topic === "rise-presentation-play" || topic === "rise-presentation-stop" ) {
       const riseElements = RisePlayerConfiguration.Helpers.getRiseElements();
 
-      setTimeout(() => {
-        console.log( `Dispatching ${topic} event` );
-        RisePlayerConfiguration.Logger.info( RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA, topic );
+      console.log( `Dispatching ${topic} event` );
+      RisePlayerConfiguration.Logger.info( RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA, topic );
 
-        riseElements.forEach( element => element.dispatchEvent( new Event( topic )));
-        window.dispatchEvent( new Event( topic ));
-      }, 100 );
+      riseElements.forEach( element => element.dispatchEvent( new Event( topic )));
+      window.dispatchEvent( new Event( topic ));
     }
   }
 

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -37,8 +37,12 @@ RisePlayerConfiguration.Viewer = (() => {
     if ( topic === "rise-presentation-play" || topic === "rise-presentation-stop" ) {
       const riseElements = RisePlayerConfiguration.Helpers.getRiseElements();
 
-      riseElements.forEach( element => element.dispatchEvent( new Event( topic )));
-      window.dispatchEvent( new Event( topic ));
+      setTimeout(() => {
+        console.log( `Dispatching ${topic} event` );
+
+        riseElements.forEach( element => element.dispatchEvent( new Event( topic )));
+        window.dispatchEvent( new Event( topic ));
+      }, 100 );
     }
   }
 

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -39,6 +39,7 @@ RisePlayerConfiguration.Viewer = (() => {
 
       setTimeout(() => {
         console.log( `Dispatching ${topic} event` );
+        RisePlayerConfiguration.Logger.info( RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA, topic );
 
         riseElements.forEach( element => element.dispatchEvent( new Event( topic )));
         window.dispatchEvent( new Event( topic ));

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -463,6 +463,16 @@ describe( "RisePlayerConfiguration", function() {
       RisePlayerConfiguration.dispatchWindowEvent( "DOMContentLoaded" );
     });
 
+    it( "should send rise-presentation-play when not on viewer and document has already finished loading", function() {
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isInViewer" ).returns( false );
+      _sandbox.stub( RisePlayerConfiguration, "dispatchWindowEvent" );
+
+      RisePlayerConfiguration.configure();
+
+      // document is already loaded because we're running tests on a browser-like environment
+      RisePlayerConfiguration.dispatchWindowEvent.should.have.been.calledWith( "rise-presentation-play" );
+    });
+
   });
 
 });

--- a/test/unit/rise-viewer.test.js
+++ b/test/unit/rise-viewer.test.js
@@ -7,11 +7,9 @@ describe( "Viewer", function() {
 
   var riseImage,
     riseText,
-    sandbox,
-    clock;
+    sandbox;
 
   beforeEach( function() {
-    clock = sinon.useFakeTimers();
     sandbox = sinon.sandbox.create();
 
     riseImage = { id: "rise-image-1", tagName: "rise-image", dispatchEvent: sandbox.spy() };
@@ -41,8 +39,6 @@ describe( "Viewer", function() {
   it( "should not execute on message if origin not from risevision.com", function() {
     RisePlayerConfiguration.Viewer.receiveData({ origin: "https://test.com", data: JSON.stringify({ testData: "test" }) });
 
-    clock.tick( 100 );
-
     expect( riseImage.dispatchEvent ).to.not.have.been.called;
     expect( riseText.dispatchEvent ).to.not.have.been.called;
   });
@@ -52,8 +48,6 @@ describe( "Viewer", function() {
       data: { topic: "other" },
       origin: "https://viewer.risevision.com"
     });
-
-    clock.tick( 100 );
 
     expect( riseImage.dispatchEvent ).to.not.have.been.called;
     expect( riseText.dispatchEvent ).to.not.have.been.called;
@@ -66,8 +60,6 @@ describe( "Viewer", function() {
       origin: "https://viewer.risevision.com"
     });
 
-    clock.tick( 100 );
-
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;
     expect( window.dispatchEvent ).to.have.been.called;
@@ -79,8 +71,6 @@ describe( "Viewer", function() {
       origin: "file://"
     });
 
-    clock.tick( 100 );
-
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;
     expect( window.dispatchEvent ).to.have.been.called;
@@ -91,8 +81,6 @@ describe( "Viewer", function() {
       data: { topic: "rise-presentation-stop" },
       origin: "https://viewer.risevision.com"
     });
-
-    clock.tick( 100 );
 
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;

--- a/test/unit/rise-viewer.test.js
+++ b/test/unit/rise-viewer.test.js
@@ -7,9 +7,11 @@ describe( "Viewer", function() {
 
   var riseImage,
     riseText,
-    sandbox;
+    sandbox,
+    clock;
 
   beforeEach( function() {
+    clock = sinon.useFakeTimers();
     sandbox = sinon.sandbox.create();
 
     riseImage = { id: "rise-image-1", tagName: "rise-image", dispatchEvent: sandbox.spy() };
@@ -39,6 +41,8 @@ describe( "Viewer", function() {
   it( "should not execute on message if origin not from risevision.com", function() {
     RisePlayerConfiguration.Viewer.receiveData({ origin: "https://test.com", data: JSON.stringify({ testData: "test" }) });
 
+    clock.tick( 100 );
+
     expect( riseImage.dispatchEvent ).to.not.have.been.called;
     expect( riseText.dispatchEvent ).to.not.have.been.called;
   });
@@ -48,6 +52,8 @@ describe( "Viewer", function() {
       data: { topic: "other" },
       origin: "https://viewer.risevision.com"
     });
+
+    clock.tick( 100 );
 
     expect( riseImage.dispatchEvent ).to.not.have.been.called;
     expect( riseText.dispatchEvent ).to.not.have.been.called;
@@ -60,6 +66,8 @@ describe( "Viewer", function() {
       origin: "https://viewer.risevision.com"
     });
 
+    clock.tick( 100 );
+
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;
     expect( window.dispatchEvent ).to.have.been.called;
@@ -71,6 +79,8 @@ describe( "Viewer", function() {
       origin: "file://"
     });
 
+    clock.tick( 100 );
+
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;
     expect( window.dispatchEvent ).to.have.been.called;
@@ -81,6 +91,8 @@ describe( "Viewer", function() {
       data: { topic: "rise-presentation-stop" },
       origin: "https://viewer.risevision.com"
     });
+
+    clock.tick( 100 );
 
     expect( riseImage.dispatchEvent ).to.have.been.called;
     expect( riseText.dispatchEvent ).to.have.been.called;


### PR DESCRIPTION
## Description
Sends `rise-presentation-play` event on non-viewer mode if document has already been loaded.

## Motivation and Context

Fixes PUD issues https://github.com/Rise-Vision/rise-play-until-done/issues/9 and https://github.com/Rise-Vision/rise-play-until-done/issues/10 

## How Has This Been Tested?
Tested with the auto-updating templates pointing to a staged version of common-template. Unit test added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
