### PR TITLE
Fix/issue 592 send rise components ready to viewer

### DIFF
--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -51,14 +51,7 @@ RisePlayerConfiguration.PlayUntilDone = (() => {
     _reset();
 
     if ( RisePlayerConfiguration.Helpers.isInViewer()) {
-
-      let message = {
-        topic: "template-done",
-        frameElementId: window.frameElement ? window.frameElement.id : ""
-      }
-
-      window.parent.postMessage( message, "*" );
-
+      RisePlayerConfiguration.Viewer.send( "template-done" );
     } else {
 
       if ( !RisePlayerConfiguration.LocalMessaging.isConnected()) {

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -219,6 +219,10 @@ const RisePlayerConfiguration = (() => {
         .then(() => {
           RisePlayerConfiguration.dispatchWindowEvent( "rise-components-ready" );
 
+          if ( RisePlayerConfiguration.Helpers.isInViewer()) {
+            RisePlayerConfiguration.Viewer.send( "rise-components-ready" );
+          }
+
           if ( !RisePlayerConfiguration.isPreview()) {
             RisePlayerConfiguration.Logger.info(
               RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA,

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -24,7 +24,7 @@ RisePlayerConfiguration.Viewer = (() => {
   }
 
   function send( topic ) {
-    let message = {
+    const message = {
       topic,
       frameElementId: window.frameElement ? window.frameElement.id : ""
     }

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -23,6 +23,15 @@ RisePlayerConfiguration.Viewer = (() => {
     window.addEventListener( "message", _receiveData, false );
   }
 
+  function send( topic ) {
+    let message = {
+      topic,
+      frameElementId: window.frameElement ? window.frameElement.id : ""
+    }
+
+    window.parent.postMessage( message, "*" );
+  }
+
   function _receiveData( event ) {
     //NOTE: checking for "risevision.com" event.origin will not work in offline mode
 
@@ -47,6 +56,7 @@ RisePlayerConfiguration.Viewer = (() => {
 
   const exposedFunctions = {
     isFirstPresentationInSchedule,
+    send,
     startListeningForData
   };
 

--- a/test/unit/rise-play-until-done.test.js
+++ b/test/unit/rise-play-until-done.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, sinon, expect, beforeEach, afterEach */
+/* global describe, it, sinon, beforeEach, afterEach */
 /* eslint-disable no-console, brace-style */
 
 "use strict";

--- a/test/unit/rise-player-configuration.test.js
+++ b/test/unit/rise-player-configuration.test.js
@@ -401,10 +401,12 @@ describe( "RisePlayerConfiguration", function() {
       _sandbox.stub( RisePlayerConfiguration, "dispatchWindowEvent" );
       _sandbox.stub( RisePlayerConfiguration.AttributeDataWatch, "watchAttributeDataFile" );
       _sandbox.stub( RisePlayerConfiguration.Preview, "startListeningForData" );
+      _sandbox.stub( RisePlayerConfiguration.Viewer, "send" );
     });
 
     it( "should start listening for data if it's preview", function() {
       _sandbox.stub( RisePlayerConfiguration, "isPreview" ).returns( true );
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isInViewer" ).returns( false );
 
       return RisePlayerConfiguration.sendComponentsReadyEvent()
         .then( function() {
@@ -413,14 +415,33 @@ describe( "RisePlayerConfiguration", function() {
 
           RisePlayerConfiguration.Preview.startListeningForData.should.have.been.called;
           RisePlayerConfiguration.AttributeDataWatch.watchAttributeDataFile.should.not.have.been.called;
+          RisePlayerConfiguration.Viewer.send.should.not.have.been.called;
         });
     });
 
     it( "should watch attribute data file if it's not preview", function() {
       _sandbox.stub( RisePlayerConfiguration, "isPreview" ).returns( false );
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isInViewer" ).returns( false );
 
       return RisePlayerConfiguration.sendComponentsReadyEvent()
         .then( function() {
+          RisePlayerConfiguration.dispatchWindowEvent.should.have.been.called.once;
+          RisePlayerConfiguration.dispatchWindowEvent.should.have.been.calledWith( "rise-components-ready" );
+
+          RisePlayerConfiguration.Preview.startListeningForData.should.not.have.been.called;
+          RisePlayerConfiguration.AttributeDataWatch.watchAttributeDataFile.should.have.been.called;
+          RisePlayerConfiguration.Viewer.send.should.not.have.been.called;
+        });
+    });
+
+    it( "should send rise-components-ready to viewer", function() {
+      _sandbox.stub( RisePlayerConfiguration, "isPreview" ).returns( false );
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isInViewer" ).returns( true );
+
+      return RisePlayerConfiguration.sendComponentsReadyEvent()
+        .then( function() {
+          RisePlayerConfiguration.Viewer.send.should.have.been.calledWith( "rise-components-ready" );
+
           RisePlayerConfiguration.dispatchWindowEvent.should.have.been.called.once;
           RisePlayerConfiguration.dispatchWindowEvent.should.have.been.calledWith( "rise-components-ready" );
 


### PR DESCRIPTION
## Description
RisePlayerConfiguration sends 'rise-components-ready' to Viewer.

## Motivation and Context
Initial change so the fix for issue 592 can be implemented as discussed here:
https://docs.google.com/document/d/1GQuyUCU9P290dWtWKwXvsGCpDdd3Jy1dhM_i-cVAHUA/edit

Next changes in Viewer requires this.

The previous change for issue 592 will be removed later so it can be released simultaneously with upcoming Viewer changes.

## How Has This Been Tested?
Unit tests were added.

I ran E2E tests here to validate that common-template is working: 
https://circleci.com/workflow-run/61a69511-bd81-4ead-89c3-31591f102777

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday
     - Low risk change; simple rollback required if there is any issue.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation or to notify support.
