### PR TITLE
E2e/issue 592 remove old fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
       - run: mkdir ~/rvplayer
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
       - run: echo proxy= >> $PLAYER_CONFIG
+      - run: echo "debugviewerurl=https://rvaviewer-test.appspot.com/Viewer.html" >> $PLAYER_CONFIG
       - run:
           name: prepare the test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ jobs:
       - run: mkdir ~/rvplayer
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
       - run: echo proxy= >> $PLAYER_CONFIG
-      - run: echo "debugviewerurl=https://issue-592-dot-rvaviewer-test.appspot.com/Viewer.html" >> $PLAYER_CONFIG
       - run:
           name: prepare the test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
       - run: mkdir ~/rvplayer
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
       - run: echo proxy= >> $PLAYER_CONFIG
-      - run: echo "debugviewerurl=https://rvaviewer-test.appspot.com/Viewer.html" >> $PLAYER_CONFIG
+      - run: echo "debugviewerurl=https://issue-592-dot-rvaviewer-test.appspot.com/Viewer.html" >> $PLAYER_CONFIG
       - run:
           name: prepare the test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,31 @@ workflows:
             branches:
               only:
                 - build/stable
+      - test-e2e-electron:
+          stage: beta
+          displayId: 5R7E98DTR2T9
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/beta/
+          name: test-common-legacy+2htmls-e2e-electron-beta
+          requires:
+            - deploy-stage
+            - deploy-common-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^e2e[/].*/
+      - test-e2e-electron:
+          stage: stable
+          displayId: XYB7Y7XQR342
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/
+          name: test-common-legacy+2htmls-e2e-electron-stable
+          requires:
+            - deploy-stage
+            - deploy-common-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
       - deploy-production:
           stage: beta
           name: deploy-beta
@@ -449,6 +474,7 @@ workflows:
             - test-common-single-e2e-electron-beta
             - test-common-multiple-e2e-electron-beta
             - test-common-legacy+html-e2e-electron-beta
+            - test-common-legacy+2htmls-e2e-electron-beta
             - gcloud-setup
           filters:
             branches:
@@ -462,6 +488,7 @@ workflows:
             - test-common-single-e2e-electron-stable
             - test-common-multiple-e2e-electron-stable
             - test-common-legacy+html-e2e-electron-stable
+            - test-common-legacy+2htmls-e2e-electron-stable
             - gcloud-setup
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,6 +416,31 @@ workflows:
             branches:
               only:
                 - build/stable
+      - test-e2e-electron:
+          stage: beta
+          displayId: G4V2XEB2J69R
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/beta/
+          name: test-common-legacy+html-e2e-electron-beta
+          requires:
+            - deploy-stage
+            - deploy-common-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^e2e[/].*/
+      - test-e2e-electron:
+          stage: stable
+          displayId: MCXUAAKYUJP8
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/
+          name: test-common-legacy+html-e2e-electron-stable
+          requires:
+            - deploy-stage
+            - deploy-common-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
       - deploy-production:
           stage: beta
           name: deploy-beta
@@ -423,6 +448,7 @@ workflows:
             - test-component-e2e-electron-beta
             - test-common-single-e2e-electron-beta
             - test-common-multiple-e2e-electron-beta
+            - test-common-legacy+html-e2e-electron-beta
             - gcloud-setup
           filters:
             branches:
@@ -435,6 +461,7 @@ workflows:
             - test-component-e2e-electron-stable
             - test-common-single-e2e-electron-stable
             - test-common-multiple-e2e-electron-stable
+            - test-common-legacy+html-e2e-electron-stable
             - gcloud-setup
           filters:
             branches:

--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -146,9 +146,7 @@ const RisePlayerConfiguration = (() => {
 
     if ( isInViewer ) {
       RisePlayerConfiguration.Viewer.startListeningForData();
-    }
-
-    if ( !isInViewer || RisePlayerConfiguration.Viewer.isFirstPresentationInSchedule()) {
+    } else {
       _sendRisePresentationPlayOnDocumentLoad();
     }
 

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -2,23 +2,6 @@
 
 RisePlayerConfiguration.Viewer = (() => {
 
-  function isFirstPresentationInSchedule() {
-    if ( !RisePlayerConfiguration.Helpers.isInViewer()) {
-      throw new Error( "Not in viewer" );
-    }
-
-    try {
-      const iframeId = window.frameElement.id || "";
-
-      return /^iFrame_sc\d+_pre0$/.test( iframeId );
-    } catch ( error ) {
-      console.error( "can't retrieve frame id", error );
-
-      // don't assume it's the first if it can't be determined.
-      return false;
-    }
-  }
-
   function startListeningForData() {
     window.addEventListener( "message", _receiveData, false );
   }
@@ -55,7 +38,6 @@ RisePlayerConfiguration.Viewer = (() => {
   }
 
   const exposedFunctions = {
-    isFirstPresentationInSchedule,
     send,
     startListeningForData
   };


### PR DESCRIPTION
## Description
Fix for issue 592.

This needs to be deployed right after changes to Viewer: https://github.com/Rise-Vision/viewer/pull/333

## Motivation and Context
See design document: https://docs.google.com/document/d/1GQuyUCU9P290dWtWKwXvsGCpDdd3Jy1dhM_i-cVAHUA/edit

## How Has This Been Tested?

Manually tested using this schedule:

https://apps.risevision.com/schedules/details/42dc0db9-07e9-453c-9a1f-6dc38cb15f9c?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

For it to work, the display should configure this line in rvplayer/RiseDisplayNetworkII.ini:

```
debugviewerurl=https://issue-592-dot-rvaviewer-test.appspot.com/Viewer.html
```

That staged viewer has debug turned on, so order of messages can be easily verified on the browser's console.

2 [new E2E test cases](https://circleci.com/workflow-run/b40f119b-c3bb-4b5a-ae4b-8e9a1e15a84e) were added covering the following scenarios:
- 592 issue - a schedule starting with a regular presentation and a template that depends on rise-presentation-play
- 592 issue with a PUD template between.

For E2E tests to work before Viewer changes have been released, the viewer URL has been fixed to a staging server. But that configuration will be undone once production viewer has been deployed.

## Release Plan:
Same as related PR

#### Release Checklist Items Skipped?
Same as related PR
