### PR TITLE
Fix error handling on watch

### DIFF
--- a/src/rise-watch.js
+++ b/src/rise-watch.js
@@ -23,7 +23,7 @@ RisePlayerConfiguration.Watch = (() => {
 
     switch ( message.status.toUpperCase()) {
     case "CURRENT":
-      return _handleFileAvailable( message, handlerSuccess );
+      return _handleFileAvailable( message, handlerSuccess, handlerError );
 
     case "FILE-ERROR":
       RisePlayerConfiguration.Logger.error(
@@ -43,7 +43,7 @@ RisePlayerConfiguration.Watch = (() => {
     return Promise.resolve();
   }
 
-  function _handleFileAvailable( message, handlerSuccess ) {
+  function _handleFileAvailable( message, handlerSuccess, handlerError ) {
     var fileUrl = message.fileUrl;
     var extractedData;
 
@@ -61,6 +61,9 @@ RisePlayerConfiguration.Watch = (() => {
             stack: error.stack || error
           }
         );
+        if ( handlerError ) {
+          return handlerError( error );
+        }
       });
   }
 

--- a/test/unit/rise-watch.test.js
+++ b/test/unit/rise-watch.test.js
@@ -128,6 +128,28 @@ describe( "Watch", function() {
         });
     });
 
+    it( "should log error and call error handler if there was an error when reading the file", function() {
+
+      RisePlayerConfiguration.Helpers.getLocalMessagingJsonContent.restore();
+
+      var parsingError = new Error( "Error when parsing" );
+
+      sinon.stub( RisePlayerConfiguration.Helpers, "getLocalMessagingJsonContent", function() {
+        return Promise.reject( parsingError );
+      });
+
+      return RisePlayerConfiguration.Watch.handleFileUpdateMessage({
+        status: "CURRENT",
+        fileUrl: "http://localhost/sample"
+      }, handlerSuccessStub, handlerErrorStub )
+        .then( function() {
+          expect( handlerSuccessStub.called ).to.be.false;
+          expect( handlerErrorStub.called ).to.be.true;
+          expect( RisePlayerConfiguration.Logger.error.called ).to.be.true;
+          expect( RisePlayerConfiguration.Logger.error.lastCall.args[ 1 ]).to.equal( "data file read error" );
+        });
+    });
+
     it( "should detect insufficient disk space", function() {
 
       return RisePlayerConfiguration.Watch.handleFileUpdateMessage({


### PR DESCRIPTION
## Description
Make sure error handler is called when there is an error reading a watched JSON local file such as attribute-data.json

## Motivation and Context

Start event is not sent even when attribute-data.json can't be parsed. This is causing some templates to get stuck showing a white screen when template is configure as PUD and parsing attribute-data.json fails such as in https://github.com/Rise-Vision/chrome-os-player/issues/241

## How Has This Been Tested?
Tested locally with Chrome OS Player and common-template library locally mapped with Charles proxy

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
