### PR TITLE
Do not track play until done event for rise-playlist-item

### DIFF
--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -17,7 +17,9 @@ RisePlayerConfiguration.PlayUntilDone = (() => {
 
   function start() {
     const riseElements = RisePlayerConfiguration.Helpers.getRiseElements();
-    const playUntilDoneElements = riseElements.filter( element => element.hasAttribute( "play-until-done" ) || element.tagName.toLowerCase() === "rise-play-until-done" );
+    const playUntilDoneElements = riseElements
+      .filter( element => element.tagName.toLowerCase() !== "rise-playlist-item" )
+      .filter( element => element.hasAttribute( "play-until-done" ) || element.tagName.toLowerCase() === "rise-play-until-done" );
 
     console.log( `Start listening PUD events of ${playUntilDoneElements.length} elements` );
     RisePlayerConfiguration.Logger.info( LOGGER_DATA, "start listening PUD events", { playUntilDoneElements: playUntilDoneElements.length });

--- a/test/unit/rise-play-until-done.test.js
+++ b/test/unit/rise-play-until-done.test.js
@@ -18,7 +18,9 @@ describe( "PlayUntilDone", function() {
       "rise-image-1": { id: "rise-image-1", tagName: "rise-image", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() },
       "rise-image-2": { id: "rise-image-2", tagName: "rise-image", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() },
       "rise-text-1": { id: "rise-text-1", tagName: "rise-text", hasAttribute: function() { return false; }, addEventListener: sandbox.stub() },
-      "rise-play-until-done-1": { id: "rise-play-until-done-1", tagName: "rise-play-until-done", hasAttribute: function() { return false; }, addEventListener: sandbox.stub() }
+      "rise-play-until-done-1": { id: "rise-play-until-done-1", tagName: "rise-play-until-done", hasAttribute: function() { return false; }, addEventListener: sandbox.stub() },
+      "rise-playlist-1": { id: "rise-playlist-1", tagName: "rise-playlist", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() },
+      "rise-playlist-item-1": { id: "rise-playlist-item-done-1", tagName: "rise-playlist-item", hasAttribute: function() { return true; }, addEventListener: sandbox.stub() }
     };
 
     sandbox.stub( RisePlayerConfiguration.Helpers, "getRiseElements", function() {
@@ -39,6 +41,8 @@ describe( "PlayUntilDone", function() {
       expectedComponents[ "rise-image-2" ].addEventListener.should.have.been.calledWith( "report-done" );
       expectedComponents[ "rise-play-until-done-1" ].addEventListener.should.have.been.calledWith( "report-done" );
       expectedComponents[ "rise-text-1" ].addEventListener.should.not.have.been.calledWith( "report-done" );
+      expectedComponents[ "rise-playlist-1" ].addEventListener.should.have.been.calledWith( "report-done" );
+      expectedComponents[ "rise-playlist-item-1" ].addEventListener.should.not.have.been.calledWith( "report-done" );
     });
 
     it( "should log PUD state every minute", function() {
@@ -63,6 +67,7 @@ describe( "PlayUntilDone", function() {
       expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
       expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: true } });
       expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: true } });
+      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true } });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 
@@ -76,6 +81,7 @@ describe( "PlayUntilDone", function() {
       expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
       expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: false } });
       expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: false } });
+      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true } });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 


### PR DESCRIPTION
## Description
Ignore rise-playlist-item elements on PUD tracker

## Motivation and Context
Implement PUD for `rise-playlist`. The `rise-playlist-item` elements are always children of `rise-playlist` and its PUD is handled by `rise-playlist` as implemented in https://github.com/Rise-Vision/rise-playlist-new/pull/7.

## How Has This Been Tested?
Tested locally on Chrome player.
Added unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
