### PR TITLE
Check PUD event target

### DIFF
--- a/src/rise-play-until-done.js
+++ b/src/rise-play-until-done.js
@@ -26,7 +26,7 @@ RisePlayerConfiguration.PlayUntilDone = (() => {
 
     playUntilDoneElements.forEach( element => {
       element.addEventListener( "report-done", event => {
-        if ( event.detail && event.detail.done && doneElements.indexOf( element ) < 0 ) {
+        if ( event.detail && event.detail.done && doneElements.indexOf( element ) < 0 && event.target === element ) {
           doneElements.push( element );
         }
 

--- a/test/unit/rise-play-until-done.test.js
+++ b/test/unit/rise-play-until-done.test.js
@@ -64,24 +64,23 @@ describe( "PlayUntilDone", function() {
     it( "should send 'template-done' when all PUD components are done", function() {
       sandbox.stub( RisePlayerConfiguration.PlayUntilDone, "reportTemplateDone" );
 
-      expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
-      expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: true } });
-      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: true } });
-      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true } });
+      expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-image-1" ] });
+      expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-image-2" ] });
+      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-play-until-done-1" ] });
+      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-playlist-1" ] });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 
       RisePlayerConfiguration.PlayUntilDone.reportTemplateDone.should.have.been.called;
     });
 
-
     it( "should not send 'template-done' when not every PUD components is done", function() {
       sandbox.stub( RisePlayerConfiguration.PlayUntilDone, "reportTemplateDone" );
 
-      expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true } });
-      expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: false } });
-      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: false } });
-      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true } });
+      expectedComponents[ "rise-image-1" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-image-1" ] });
+      expectedComponents[ "rise-image-2" ].addEventListener.yields({ detail: { done: false }, target: expectedComponents[ "rise-image-2" ] });
+      expectedComponents[ "rise-play-until-done-1" ].addEventListener.yields({ detail: { done: false }, target: expectedComponents[ "rise-play-until-done-1" ] });
+      expectedComponents[ "rise-playlist-1" ].addEventListener.yields({ detail: { done: true }, target: expectedComponents[ "rise-playlist-1" ] });
 
       RisePlayerConfiguration.PlayUntilDone.start();
 


### PR DESCRIPTION
## Description
- Do not report element is done when event target is different. This can happen when a child element sends the "report-event". For instance, when a rise-playlist element has a rise-embedded-template child that sends the "report-done" it should not be considered done until the rise-playlist element itself sends the event.

## Motivation and Context
`rise-playlist` element should not report-done when a child `rise-embedded-template` reports done

## How Has This Been Tested?
Tested locally on Chrome player

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
