### PR TITLE
Provide helper function for determining if running in editor staging

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -34,6 +34,30 @@ RisePlayerConfiguration.Helpers = (() => {
     return RisePlayerConfiguration.getDisplayId() !== "preview";
   }
 
+  function isEditorStaging() {
+    if ( RisePlayerConfiguration.Helpers.isEditorPreview()) {
+      try {
+        const pathname = RisePlayerConfiguration.Helpers.getLocationPathname();
+        const parts = pathname.split( "/" );
+
+        // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
+        // pathname for above would be:  /staging/templates/abc123/src/template.html
+
+        if ( parts[ 1 ] === "staging" ) {
+          return true
+        }
+      } catch ( err ) {
+        console.log( "can't retrieve window location pathname", err );
+      }
+    }
+
+    return false;
+  }
+
+  function getLocationPathname() {
+    return window.location.pathname;
+  }
+
   function onceClientsAreAvailable( requiredClientNames, action ) {
     let invoked = false;
     const names = typeof requiredClientNames === "string" ?
@@ -183,11 +207,13 @@ RisePlayerConfiguration.Helpers = (() => {
     getRiseEditableElements: getRiseEditableElements,
     getRisePlayerConfiguration: getRisePlayerConfiguration,
     getWaitForPlayerURLParam: getWaitForPlayerURLParam,
+    getLocationPathname: getLocationPathname,
     isTestEnvironment: isTestEnvironment,
     isInViewer: isInViewer,
     isSharedSchedule: isSharedSchedule,
     isEditorPreview: isEditorPreview,
     isDisplay: isDisplay,
+    isEditorStaging: isEditorStaging,
     getSharedScheduleUnsupportedElements: getSharedScheduleUnsupportedElements,
     onceClientsAreAvailable: onceClientsAreAvailable,
     sendStartEvent: sendStartEvent,

--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -34,21 +34,19 @@ RisePlayerConfiguration.Helpers = (() => {
     return RisePlayerConfiguration.getDisplayId() !== "preview";
   }
 
-  function isEditorStaging() {
-    if ( RisePlayerConfiguration.Helpers.isEditorPreview()) {
-      try {
-        const pathname = RisePlayerConfiguration.Helpers.getLocationPathname();
-        const parts = pathname.split( "/" );
+  function isStaging() {
+    try {
+      const pathname = RisePlayerConfiguration.Helpers.getLocationPathname();
+      const parts = pathname.split( "/" );
 
-        // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
-        // pathname for above would be:  /staging/templates/abc123/src/template.html
+      // example window location:  https://widgets.risevision.com/staging/templates/abc123/src/template.html?type=preview&presentationId=abc123
+      // pathname for above would be:  /staging/templates/abc123/src/template.html
 
-        if ( parts[ 1 ] === "staging" ) {
-          return true
-        }
-      } catch ( err ) {
-        console.log( "can't retrieve window location pathname", err );
+      if ( parts[ 1 ] === "staging" ) {
+        return true
       }
+    } catch ( err ) {
+      console.log( "can't retrieve window location pathname", err );
     }
 
     return false;
@@ -213,7 +211,7 @@ RisePlayerConfiguration.Helpers = (() => {
     isSharedSchedule: isSharedSchedule,
     isEditorPreview: isEditorPreview,
     isDisplay: isDisplay,
-    isEditorStaging: isEditorStaging,
+    isStaging: isStaging,
     getSharedScheduleUnsupportedElements: getSharedScheduleUnsupportedElements,
     onceClientsAreAvailable: onceClientsAreAvailable,
     sendStartEvent: sendStartEvent,

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -98,25 +98,17 @@ describe( "Helpers", function() {
     });
   });
 
-  describe( "isEditorStaging", function() {
+  describe( "isStaging", function() {
     it( "should return true if 'staging' is in window location pathname", function() {
-      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( true );
       _sandbox.stub( RisePlayerConfiguration.Helpers, "getLocationPathname" ).returns( "/staging/templates/abc123/src/template.html" );
 
-      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.true;
+      expect( RisePlayerConfiguration.Helpers.isStaging()).to.be.true;
     });
 
     it( "should return false if 'staging' is not in window location pathname", function() {
-      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( true );
       _sandbox.stub( RisePlayerConfiguration.Helpers, "getLocationPathname" ).returns( "/stable/templates/abc123/src/template.html" );
 
-      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.false;
-    });
-
-    it( "should return false if not running in Editor Preview", function() {
-      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( false );
-
-      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.false;
+      expect( RisePlayerConfiguration.Helpers.isStaging()).to.be.false;
     });
   });
 

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -98,6 +98,28 @@ describe( "Helpers", function() {
     });
   });
 
+  describe( "isEditorStaging", function() {
+    it( "should return true if 'staging' is in window location pathname", function() {
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( true );
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "getLocationPathname" ).returns( "/staging/templates/abc123/src/template.html" );
+
+      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.true;
+    });
+
+    it( "should return false if 'staging' is not in window location pathname", function() {
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( true );
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "getLocationPathname" ).returns( "/stable/templates/abc123/src/template.html" );
+
+      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.false;
+    });
+
+    it( "should return false if not running in Editor Preview", function() {
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "isEditorPreview" ).returns( false );
+
+      expect( RisePlayerConfiguration.Helpers.isEditorStaging()).to.be.false;
+    });
+  });
+
   describe( "isDisplay", function() {
     it( "should return true if a valid display id is provided", function() {
       _sandbox.stub( RisePlayerConfiguration, "getDisplayId" ).returns( "DISPLAYID" );


### PR DESCRIPTION
## Description
Provide helper function for determining if a component or template is running in editor staging

Determines based on checking if running in editor preview and if so then check `window.location/pathname`  if it starts with _staging_. 

## Motivation and Context
Twitter component requires to know if running in editor staging in order to know if it should request to staging cluster of Twitter service. 

## How Has This Been Tested?
Unit tests and locally with rise-data-twitter component running on Apps staging

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
