### PR TITLE
Re-send “rise-presentation-play” event

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -8,6 +8,7 @@ RisePlayerConfiguration.Helpers = (() => {
   ];
   let _clients = [];
   let _riseElements = null;
+  let _risePresentationPlayReceived = false;
 
   function _clientsAreAvailable( names ) {
     return names.every( name => _clients.indexOf( name ) >= 0 );
@@ -186,15 +187,24 @@ RisePlayerConfiguration.Helpers = (() => {
     // Start the component once it's configured;
     // but if it's already configured the listener won't work,
     // so we directly send the request also.
-    component.addEventListener( "configured", () =>
-      component.dispatchEvent( new CustomEvent( "start" ))
-    );
+    component.addEventListener( "configured", () => {
+      component.dispatchEvent( new CustomEvent( "start" ));
+
+      if ( _risePresentationPlayReceived ) {
+        component.dispatchEvent( new Event( "rise-presentation-play" ));
+      }
+    });
+
     component.dispatchEvent( new CustomEvent( "start" ));
   }
 
   function reset() {
     _clients = [];
     _riseElements = null;
+  }
+
+  function setRisePresentationPlayReceived( value ) {
+    _risePresentationPlayReceived = value;
   }
 
   const exposedFunctions = {
@@ -215,7 +225,8 @@ RisePlayerConfiguration.Helpers = (() => {
     getSharedScheduleUnsupportedElements: getSharedScheduleUnsupportedElements,
     onceClientsAreAvailable: onceClientsAreAvailable,
     sendStartEvent: sendStartEvent,
-    getComponent: getComponent
+    getComponent: getComponent,
+    setRisePresentationPlayReceived: setRisePresentationPlayReceived
   };
 
   if ( isTestEnvironment()) {

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -30,6 +30,9 @@ RisePlayerConfiguration.Viewer = (() => {
     const topic = message.topic.toLowerCase();
 
     if ( topic === "rise-presentation-play" || topic === "rise-presentation-stop" ) {
+
+      RisePlayerConfiguration.Helpers.setRisePresentationPlayReceived( topic === "rise-presentation-play" );
+
       const riseElements = RisePlayerConfiguration.Helpers.getRiseElements();
 
       console.log( `Dispatching ${topic} event` );

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -162,6 +162,41 @@ describe( "Helpers", function() {
     });
   });
 
+  describe( "rise-component loaded after common-template", function() {
+
+    var element;
+    var handleStart;
+    var handlePlay;
+
+    beforeEach( function() {
+      element = document.createElement( "rise-image" );
+
+      RisePlayerConfiguration.Helpers.sendStartEvent( element );
+
+      handleStart = sinon.stub();
+      handlePlay = sinon.stub();
+
+      element.addEventListener( "start", handleStart );
+      element.addEventListener( "rise-presentation-play", handlePlay );
+    });
+
+    it( "should re-send 'start' event", function() {
+      element.dispatchEvent( new CustomEvent( "configured", { bubbles: true, composed: true }));
+
+      expect( handleStart.calledOnce ).to.be.true;
+      expect( handlePlay.called ).to.be.false;
+    });
+
+    it( "should re-send 'rise-presentation-play' event", function() {
+      RisePlayerConfiguration.Helpers.setRisePresentationPlayReceived( true );
+
+      element.dispatchEvent( new CustomEvent( "configured", { bubbles: true, composed: true }));
+
+      expect( handleStart.calledOnce ).to.be.true;
+      expect( handlePlay.calledOnce ).to.be.true;
+    });
+  });
+
   describe( "getLocalMessagingJsonContent", function() {
 
     var xhr,


### PR DESCRIPTION
## Description
Send “rise-presentation-play” event to the Rise Component when "configured" event is received.

## Motivation and Context
Common-template and Rise Components are loaded in different order. Common-template does not wait for Rise Components to be loaded and ready before sending “rise-presentation-play”. This creates a situation when components miss the “rise-presentation-play” event. We have the same problem with the "start" event and it is solved the same way - resending the even when "configured" event is received.

For better clarity, a Rise Component creates event handler for the “rise-presentation-play” event after it receive "ready" event. You can see in the console log that there are situations when common-template sends “rise-presentation-play” before Rise Component receives "ready". In those case  components that rely on “rise-presentation-play” like rise-playlist do not show content.

## How Has This Been Tested?
Manually in the Rise Anywhere and in Chrome OS player. Unit tests added too.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
