### PR TITLE
Add global error handler

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -120,6 +120,16 @@ const RisePlayerConfiguration = (() => {
     Object.freeze( RisePlayerConfiguration );
   }
 
+  function _configureGlobalErrorHandler() {
+    window.onerror = function( message, source, lineno, colno, error ) {
+      RisePlayerConfiguration.Logger.error(
+        RisePlayerConfiguration.RISE_PLAYER_CONFIGURATION_DATA,
+        "template global error",
+        { message, source, lineno, colno, error }
+      );
+    };
+  }
+
   function configure( playerInfo, localMessagingInfo ) {
     _validateAllRequiredObjectsAreAvailable();
 
@@ -140,6 +150,7 @@ const RisePlayerConfiguration = (() => {
     localMessagingInfo = _init( playerInfo, localMessagingInfo );
 
     RisePlayerConfiguration.Logger.configure();
+    _configureGlobalErrorHandler();
 
     if ( RisePlayerConfiguration.isPreview()) {
       RisePlayerConfiguration.sendComponentsReadyEvent();


### PR DESCRIPTION
## Description
Improvement for https://github.com/Rise-Vision/common-template/issues/113. The original assumption was that an exception in the event handler breaks the `dispatchEvent` loop, however this is not true. The only problem is that the exception is not logged in the BQ and remain unnoticeable. This PR adds global error handler and logs errors into BQ.


## Motivation and Context
Issue https://github.com/Rise-Vision/common-template/issues/113. 

## How Has This Been Tested?
Tested locally by creating an unhandled exception in the code and confirming that logger is called.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
