### PR TITLE
clean up expired cache

### DIFF
--- a/src/rise-purge-cached-files.js
+++ b/src/rise-purge-cached-files.js
@@ -1,19 +1,24 @@
-
 /* eslint-disable no-console, one-var, vars-on-top */
 
 RisePlayerConfiguration.PurgeCacheFiles = (() => {
   const componentCacheKeys = [ "rise-image", "rise-video" ];
+  const expiryTime = 1000 * 60 * 6 * 24 * 7;
 
   function purge() {
     return new Promise(( resolve ) => {
       return _getCacheNames()
         .then( cachesNames => {
-          return _getComponentCaches( cachesNames );
+          return _getComponentCacheNames( cachesNames );
         })
-        .then( cachesToDelete => {
-          console.log( "cachesToDelete", cachesToDelete );
+        .then( componentCacheNames => {
+          return Promise.all( componentCacheNames.map( _getCache ));
+        })
+        .then( componentCaches => {
+          return Promise.all( componentCaches.map( _cleanUpCache ));
+        })
+        .then(() => {
           resolve( "done" );
-        })
+        });
     })
   }
 
@@ -21,7 +26,7 @@ RisePlayerConfiguration.PurgeCacheFiles = (() => {
     return window.caches.keys();
   }
 
-  function _getComponentCaches( cacheNames ) {
+  function _getComponentCacheNames( cacheNames ) {
     return cacheNames.reduce(( acc, value ) => {
       if ( componentCacheKeys.find( key => value.indexOf( key ) > -1 )) {
         acc.push( value );
@@ -31,6 +36,33 @@ RisePlayerConfiguration.PurgeCacheFiles = (() => {
     }, []);
   }
 
+  function _getCache( name ) {
+    return window.caches.open( name );
+  }
+
+  function _cleanUpCache( cache ) {
+    const currentTimestamp = new Date();
+
+    return cache.matchAll().then( cachedEntries => {
+      cachedEntries.forEach( entry => {
+        const lastRequested = entry.headers.get( "date" );
+
+        if ( _compareDates( currentTimestamp, lastRequested )) {
+          cache.delete( entry.url );
+        }
+      })
+    })
+  }
+
+  function _compareDates( currentTimestamp, lastRequested ) {
+    const difference = currentTimestamp.valueOf() - new Date( lastRequested ).valueOf();
+
+    if ( difference >= expiryTime ) {
+      return true;
+    }
+    return false;
+  }
+
   const exposedFunctions = {
     purge: purge
   }
@@ -38,7 +70,10 @@ RisePlayerConfiguration.PurgeCacheFiles = (() => {
   if ( RisePlayerConfiguration.Helpers.isTestEnvironment()) {
     Object.assign( exposedFunctions, {
       getCacheNames: _getCacheNames,
-      getComponentCaches: _getComponentCaches
+      getComponentCacheNames: _getComponentCacheNames,
+      getCache: _getCache,
+      cleanUpCache: _cleanUpCache,
+      compareDates: _compareDates
     });
   }
 

--- a/src/rise-purge-cached-files.js
+++ b/src/rise-purge-cached-files.js
@@ -2,7 +2,7 @@
 
 RisePlayerConfiguration.PurgeCacheFiles = (() => {
   const componentCacheKeys = [ "rise-image", "rise-video" ];
-  const expiryTime = 1000 * 60 * 6 * 24 * 7;
+  const EXPIRY_TIME = 1000 * 60 * 60 * 24 * 7;
 
   function purge() {
     return new Promise(( resolve ) => {
@@ -55,9 +55,9 @@ RisePlayerConfiguration.PurgeCacheFiles = (() => {
   }
 
   function _compareDates( currentTimestamp, lastRequested ) {
-    const difference = currentTimestamp.valueOf() - new Date( lastRequested ).valueOf();
+    const difference = currentTimestamp.getTime() - new Date( lastRequested ).getTime();
 
-    if ( difference >= expiryTime ) {
+    if ( difference >= EXPIRY_TIME ) {
       return true;
     }
     return false;

--- a/test/unit/rise-purge-cached-files.test.js
+++ b/test/unit/rise-purge-cached-files.test.js
@@ -12,6 +12,9 @@ describe( "PurgeCacheFiles", function() {
     sandbox.stub( window, "caches" ).value({
       keys: function() {
         return [ "rise-image/Value 1", "rise-video/Value 2", "custom/Value 2" ];
+      },
+      open: function( name ) {
+        return name;
       }
     });
   })
@@ -20,22 +23,94 @@ describe( "PurgeCacheFiles", function() {
     sandbox.restore();
   });
 
-  it( "getCachesNames should return caches keys", function() {
+  it( "getCacheNames should return caches keys", function() {
     var response = RisePlayerConfiguration.PurgeCacheFiles.getCacheNames();
 
     expect( response ).to.deep.equal([ "rise-image/Value 1", "rise-video/Value 2", "custom/Value 2" ]);
   });
 
-  it( "getComponentCaches should return caches keys to delete", function() {
-    var response = RisePlayerConfiguration.PurgeCacheFiles.getComponentCaches([ "rise-image/Value 1", "rise-video/Value 2", "custom/Value 2" ]);
+  describe( "purge", function() {
+    it( "should call _getCacheNames", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.purge().then( function() {
+        expect( RisePlayerConfiguration.PurgeCacheFiles.getCacheNames.called ).to.be.true;
+      });
+    });
 
-    expect( response ).to.deep.equal([ "rise-image/Value 1", "rise-video/Value 2" ]);
-  });
+    it( "should call _getComponentCacheNames", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.purge().then( function() {
+        expect( RisePlayerConfiguration.PurgeCacheFiles.getComponentCacheNames.called ).to.be.true;
+      });
+    });
 
-  it( "should resolve with 'done' message", function() {
-    RisePlayerConfiguration.PurgeCacheFiles.purge().then( function( res ) {
-      expect( res ).to.be( "done" );
+    it( "should call _getCache", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.purge().then( function() {
+        expect( RisePlayerConfiguration.PurgeCacheFiles.getCache.called ).to.be.true;
+      });
+    });
+
+    it( "should call _cleanUpCache", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.purge().then( function() {
+        expect( RisePlayerConfiguration.PurgeCacheFiles.cleanUpCache.called ).to.be.true;
+      });
+    });
+
+    it( "should resolve with 'done' message", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.purge().then( function( res ) {
+        expect( res ).to.be( "done" );
+      });
     });
   });
 
+  it( "getCache should return Caches object", function() {
+    var res = RisePlayerConfiguration.PurgeCacheFiles.getCache( "caches object" );
+
+    expect( res ).to.equal( "caches object" );
+  });
+
+  describe( "cleanUpCache", function() {
+    var cache,
+      expValue,
+      okValue;
+
+    beforeEach( function() {
+      cache = {};
+      expValue = {
+        url: "test url value",
+        headers: {
+          get: function() {
+            return new Date( "2011/10/11" );
+          }
+        }
+      };
+
+      okValue = {
+        url: "test url value",
+        headers: {
+          get: function() {
+            return new Date();
+          }
+        }
+      };
+
+      sinon.stub( cache, "delete" );
+      cache.matchAll = sinon.stub().resolves([ okValue, expValue ]);
+    });
+
+    it( "should delete all expired values", function() {
+      RisePlayerConfiguration.PurgeCacheFiles.cleanUpCache( cache ).then( function() {
+        expect( cacheValue.delete.calledWith( expValue.url )).to.be.true;
+        expect( cacheValue.delete.calledWith( okValue.url )).to.be.false;
+      });
+    });
+  });
+
+  describe( "compareDates", function() {
+    it( "should return 'true' if the current time is not expired", function() {
+      expect( RisePlayerConfiguration.PurgeCacheFiles.compareDates( new Date(), new Date()))
+    });
+
+    it( "should return 'false' if the current time is expired", function() {
+      expect( RisePlayerConfiguration.PurgeCacheFiles.compareDates( new Date(), new Date( "2011/11/10" )))
+    });
+  });
 });

--- a/test/unit/rise-purge-cached-files.test.js
+++ b/test/unit/rise-purge-cached-files.test.js
@@ -98,8 +98,8 @@ describe( "PurgeCacheFiles", function() {
 
     it( "should delete all expired values", function() {
       RisePlayerConfiguration.PurgeCacheFiles.cleanUpCache( cache ).then( function() {
-        expect( cacheValue.delete.calledWith( expValue.url )).to.be.true;
-        expect( cacheValue.delete.calledWith( okValue.url )).to.be.false;
+        expect( cache.delete.calledWith( expValue.url )).to.be.true;
+        expect( cache.delete.calledWith( okValue.url )).to.be.false;
       });
     });
   });


### PR DESCRIPTION
## Description
Open caches by filtered out cache names, iterate through its entries, find entries with date header older then seven days, delete them. Resolve done to riseplayerconfiguration

## Motivation and Context
This is for deleting old, unnecessary cache to increase cache storage and to keep it relevant

## How Has This Been Tested?
in apps with mapping to local file

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
