### PR TITLE
Revert execution of purging cache files

### DIFF
--- a/src/rise-player-configuration.js
+++ b/src/rise-player-configuration.js
@@ -156,9 +156,7 @@ const RisePlayerConfiguration = (() => {
     _configureGlobalErrorHandler();
 
     if ( RisePlayerConfiguration.isPreview()) {
-      RisePlayerConfiguration.PurgeCacheFiles.purge().then(() => {
-        RisePlayerConfiguration.sendComponentsReadyEvent();
-      })
+      RisePlayerConfiguration.sendComponentsReadyEvent();
     } else {
       _configureLocalMessaging( localMessagingInfo );
     }


### PR DESCRIPTION
## Description
The PR for executing purging cached files #126  was merged to master by mistake. Fortunately it has not been deployed to stable. In QA/testing, we have since found a bug with how it is executed from `configure()` , see [here](https://trello.com/c/89nHKZl0/54-bug-purgecachefiles-messes-up-order-of-dispatched-window-events) for detail. The PR #129 is aiming to resolve the problem. 

In the meantime, to keep master branch safe from a potential stable build of other changes, removing the previous execution of purging entirely. 

## Motivation and Context
Prevent serious issue if a stable build occurs. 

## How Has This Been Tested?
Via Charles mapping local built file of common-template. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
