### PR TITLE
Add function to get Viewer type (`type` URL param)

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -59,12 +59,16 @@ RisePlayerConfiguration.Helpers = (() => {
     return false;
   }
 
-  function getEnv() {
+  function getViewerEnv() {
     return RisePlayerConfiguration.Helpers.getHttpParameter( "env" );
   }
 
   function getViewerId() {
     return RisePlayerConfiguration.Helpers.getHttpParameter( "viewerid" );
+  }
+
+  function getViewerType() {
+    return RisePlayerConfiguration.Helpers.getHttpParameter( "type" );
   }
 
   function getLocationPathname() {
@@ -297,8 +301,9 @@ RisePlayerConfiguration.Helpers = (() => {
     isEditorPreview: isEditorPreview,
     isDisplay: isDisplay,
     isStaging: isStaging,
-    getEnv: getEnv,
+    getViewerEnv: getViewerEnv,
     getViewerId: getViewerId,
+    getViewerType: getViewerType,
     getSharedScheduleUnsupportedElements: getSharedScheduleUnsupportedElements,
     onceClientsAreAvailable: onceClientsAreAvailable,
     bindOnConfigured: bindOnConfigured,

--- a/test/unit/rise-helpers.test.js
+++ b/test/unit/rise-helpers.test.js
@@ -126,11 +126,11 @@ describe( "Helpers", function() {
     });
   });
 
-  describe( "getEnv", function() {
+  describe( "getViewerEnv", function() {
     it( "should return 'env' URL parameter", function() {
       _sandbox.stub( RisePlayerConfiguration.Helpers, "getHttpParameter" ).withArgs( "env" ).returns( "test_env" );
 
-      expect( RisePlayerConfiguration.Helpers.getEnv()).to.equal( "test_env" );
+      expect( RisePlayerConfiguration.Helpers.getViewerEnv()).to.equal( "test_env" );
     });
   });
 
@@ -139,6 +139,14 @@ describe( "Helpers", function() {
       _sandbox.stub( RisePlayerConfiguration.Helpers, "getHttpParameter" ).withArgs( "viewerid" ).returns( "test_viewer_id" );
 
       expect( RisePlayerConfiguration.Helpers.getViewerId()).to.equal( "test_viewer_id" );
+    });
+  });
+
+  describe( "getViewerType", function() {
+    it( "should return 'type' URL parameter", function() {
+      _sandbox.stub( RisePlayerConfiguration.Helpers, "getHttpParameter" ).withArgs( "type" ).returns( "test_type" );
+
+      expect( RisePlayerConfiguration.Helpers.getViewerType()).to.equal( "test_type" );
     });
   });
 


### PR DESCRIPTION
## Description
- Add function to get Viewer type. I named the function `getViewerType` because `getType` is too generic.
- Rename `getEnv` to `getViewerEnv` for the sake of consistency and because `getEnv` is also too generic and can be misleading.

## Motivation and Context
Rise Image and Rise Video need to add viewer `type` to the file request URL.

## How Has This Been Tested?
Unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
