### PR TITLE
Fix for issue 146 - Branding override not working

### DIFF
--- a/src/rise-preview.js
+++ b/src/rise-preview.js
@@ -33,6 +33,11 @@ RisePlayerConfiguration.Preview = (() => {
       return;
     }
 
+    if ( data.topic === "rise-components-ready" ) {
+      // fix for https://github.com/Rise-Vision/common-template/issues/146
+      return;
+    }
+
     switch ( data.type ) {
     case "attributeData":
       RisePlayerConfiguration.AttributeData.update( data.value );

--- a/test/unit/rise-preview.test.js
+++ b/test/unit/rise-preview.test.js
@@ -94,6 +94,17 @@ describe( "Preview", function() {
     expect( updateStub ).to.not.have.been.called;
   });
 
+  it( "should not handle 'rise-components-ready' messages because it's coming from embedded presentation", function() {
+    RisePlayerConfiguration.Preview.receiveData({
+      data: { topic: "rise-components-ready" },
+      origin: "https://widgets.risevision.com"
+    });
+
+    //confirm AttributeData.update() is not called
+    expect( updateStub ).to.not.have.been.called;
+  });
+
+
   describe( "_initDataRetrieval:", function() {
     beforeEach( function() {
       _sandbox.stub( RisePlayerConfiguration.Helpers, "isInViewer" ).returns( false );


### PR DESCRIPTION
## Description

Fix for #146. Prevent the situation when "rise-components-ready" message is mistaken for attribute data update. 

## Motivation and Context
See description in the the issue #146

## How Has This Been Tested?

- Unit test
- Locally using Charles proxy.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
