### PR TITLE
Fix for issue 2230 - Override Brand Colors is ignored

### DIFF
--- a/src/rise-preview.js
+++ b/src/rise-preview.js
@@ -33,8 +33,11 @@ RisePlayerConfiguration.Preview = (() => {
       return;
     }
 
-    if ( data.topic === "rise-components-ready" ) {
-      // fix for https://github.com/Rise-Vision/common-template/issues/146
+    if ( data.hasOwnProperty( "topic" )) {
+      // filter out commands ("rise-components-ready", "rise-presentation-play", etc.)
+      // fix for:
+      // - https://github.com/Rise-Vision/common-template/issues/146
+      // - https://github.com/Rise-Vision/rise-vision-apps/issues/2230
       return;
     }
 

--- a/test/unit/rise-preview.test.js
+++ b/test/unit/rise-preview.test.js
@@ -104,6 +104,15 @@ describe( "Preview", function() {
     expect( updateStub ).to.not.have.been.called;
   });
 
+  it( "should not handle 'rise-presentation-play' message (https://github.com/Rise-Vision/rise-vision-apps/issues/2230)", function() {
+    RisePlayerConfiguration.Preview.receiveData({
+      data: { topic: "rise-presentation-play" },
+      origin: "https://widgets.risevision.com"
+    });
+
+    //confirm AttributeData.update() is not called
+    expect( updateStub ).to.not.have.been.called;
+  });
 
   describe( "_initDataRetrieval:", function() {
     beforeEach( function() {


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/rise-vision-apps/issues/2230

This issue is similar to https://github.com/Rise-Vision/common-template/issues/146. 

Here is what causes the issue. Let's say a schedule consists of two presentations, then Viewer does the following:

- Viewer loads both presentations.
- It sends "rise-presentation-play" to the first presentation (not sure why this message is sent before attribute data)
- It sends attribute data to both presentations. The attribute data includes branding override settings. At this point both presentations have branding override applied correctly and the first presentation starts playing and renders correct colours.
- At some point Viewer sends "rise-presentation-stop" to the first presentation and "rise-presentation-play" to the second presentation. Processing of those messages trigger `RisePlayerConfiguration.AttributeData.update()` function call without attribute data ([here](https://github.com/Rise-Vision/common-template/compare/stage/fix-issue-2230?expand=1#diff-3c9264efd75e609867c4a02a3f08f1a3af46fa5898e94525390318c8da2d35d6R60)) which in turn causes the **reset of the branding override** [here](https://github.com/Rise-Vision/common-template/blob/890b3f87f56b68d00abac9766f8d2b13ee509a4e/src/rise-branding.js#L37).

The issue is fixed by filtering out all command messages ("rise-components-ready", "rise-presentation-play", "rise-presentation-stop", etc.) before calling `RisePlayerConfiguration.AttributeData.update()` function.

## Motivation and Context
Fix issue

## How Has This Been Tested?
Tested on local machine using proxy.
Added unit test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
