### PR TITLE
send presentation id with endpoint log structure

### DIFF
--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -37,6 +37,7 @@ RisePlayerConfiguration.Viewer = (() => {
         eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
         eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
         presentationId: RisePlayerConfiguration.getPresentationId(),
+        placeholderId: "",
         eventErrorCode: "E000000010",
         eventDetails: `invalid log call attempt - missing fields - ${JSON.stringify( fields )}`,
         debugInfo: new Error().stack
@@ -46,7 +47,8 @@ RisePlayerConfiguration.Viewer = (() => {
     send( "log-endpoint-event", Object.assign({}, {
       eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
       eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
-      presentationId: RisePlayerConfiguration.getPresentationId()
+      presentationId: RisePlayerConfiguration.getPresentationId(),
+      placeholderId: ""
     }, fields ));
   }
 
@@ -55,7 +57,8 @@ RisePlayerConfiguration.Viewer = (() => {
       componentId: null,
       eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
       eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
-      presentationId: RisePlayerConfiguration.getPresentationId()
+      presentationId: RisePlayerConfiguration.getPresentationId(),
+      placeholderId: ""
     }, fields ));
   }
 

--- a/src/rise-viewer.js
+++ b/src/rise-viewer.js
@@ -36,6 +36,7 @@ RisePlayerConfiguration.Viewer = (() => {
         severity: "ERROR",
         eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
         eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
+        presentationId: RisePlayerConfiguration.getPresentationId(),
         eventErrorCode: "E000000010",
         eventDetails: `invalid log call attempt - missing fields - ${JSON.stringify( fields )}`,
         debugInfo: new Error().stack
@@ -44,7 +45,8 @@ RisePlayerConfiguration.Viewer = (() => {
 
     send( "log-endpoint-event", Object.assign({}, {
       eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
-      eventAppVersion: RisePlayerConfiguration.getTemplateVersion()
+      eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
+      presentationId: RisePlayerConfiguration.getPresentationId()
     }, fields ));
   }
 
@@ -52,7 +54,8 @@ RisePlayerConfiguration.Viewer = (() => {
     send( "log-endpoint-heartbeat", Object.assign({}, {
       componentId: null,
       eventApp: `HTML Template: ${RisePlayerConfiguration.getTemplateName()}`,
-      eventAppVersion: RisePlayerConfiguration.getTemplateVersion()
+      eventAppVersion: RisePlayerConfiguration.getTemplateVersion(),
+      presentationId: RisePlayerConfiguration.getPresentationId()
     }, fields ));
   }
 

--- a/test/unit/rise-viewer.test.js
+++ b/test/unit/rise-viewer.test.js
@@ -158,6 +158,7 @@ describe( "Viewer", function() {
       eventApp: "HTML Template: TEMPLATE_NAME",
       eventAppVersion: "test-event-app-version",
       presentationId: "PRESENTATION-ID",
+      placeholderId: "",
       eventDetails: "test-event-details",
       frameElementId: "context",
       severity: "INFO"
@@ -187,6 +188,7 @@ describe( "Viewer", function() {
           eventApp: "HTML Template: TEMPLATE_NAME",
           eventAppVersion: "TEMPLATE_VERSION",
           presentationId: "PRESENTATION-ID",
+          placeholderId: "",
           frameElementId: "context"
         }, "*" );
 

--- a/test/unit/rise-viewer.test.js
+++ b/test/unit/rise-viewer.test.js
@@ -15,6 +15,7 @@ describe( "Viewer", function() {
     riseImage = {};
     riseText = {};
 
+    sandbox.stub( RisePlayerConfiguration, "getPresentationId" ).returns( "PRESENTATION-ID" );
     sandbox.stub( RisePlayerConfiguration.Helpers, "getRiseElements", function() {
       return Object.values({
         "rise-image": riseImage,
@@ -156,6 +157,7 @@ describe( "Viewer", function() {
       topic: "log-endpoint-event",
       eventApp: "HTML Template: TEMPLATE_NAME",
       eventAppVersion: "test-event-app-version",
+      presentationId: "PRESENTATION-ID",
       eventDetails: "test-event-details",
       frameElementId: "context",
       severity: "INFO"
@@ -184,6 +186,7 @@ describe( "Viewer", function() {
           componentId: null,
           eventApp: "HTML Template: TEMPLATE_NAME",
           eventAppVersion: "TEMPLATE_VERSION",
+          presentationId: "PRESENTATION-ID",
           frameElementId: "context"
         }, "*" );
 


### PR DESCRIPTION
## Description
Fixes https://github.com/Rise-Vision/viewer/issues/498

## Motivation and Context
Full analysis behind the change here: https://trello.com/c/nN8aYTiy/6367-templates-log-events-with-presentationid-that-was-not-build-from-those-templates

But basically we need to log the presentation id along with the template name/version so it doesn't happen that a template entry gets logged with a presentation id that does not correspond to that template ( because a different presentation is currently showing, or the presentation switched before the template logging event got processed ).

## How Has This Been Tested?
Unit tests were updated, and E2E tests for these changed are working: https://app.circleci.com/pipelines/github/Rise-Vision/common-template/697/workflows/54219980-5dc0-4b53-9a32-6e92135b1446

## Release Plan:
To be released immediately to master and build/stable after approval, before Friday.
Simple rollback is enough to revert these changes.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation.

FYI @stulees @olegrise 