### PR TITLE
Don't log templates as components

### DIFF
--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -245,10 +245,16 @@ RisePlayerConfiguration.Logger = (() => {
       });
     }
 
+    // Some templates are logging errors as components. componentData.name
+    // contains the template name.
+    const eventApp = componentData.name === templateData.name || !componentData.name ?
+      `HTML Template: ${templateData.name}` :
+      componentData.name;
+
     RisePlayerConfiguration.Viewer.sendEndpointLog({
       severity: level,
       eventErrorCode: ( eventDetails && eventDetails.errorCode ) || ( level === "error" ? "X" : null ),
-      eventApp: componentData.name || `HTML Template: ${templateData.name}`,
+      eventApp,
       componentId: componentData.id || null,
       eventAppVersion: componentData.name ? componentData.version : templateData.version,
       eventDetails: JSON.stringify({ event, eventDetails }),


### PR DESCRIPTION
Some templates are [logging errors with](https://github.com/Rise-Vision/html-template-library/blob/master/auto-update-history-on-this-day/src/js/main.js#L53) componentData.name set to the
template name (eg: auto-update-history-on-this-day). This causes the
eventApp field to show [template-name] instead of `HTML Template:
${templateName}`.

This correction forces the "HTML Template: " prefix when the
component.name exactly matches the template name so that the eventApp
consistently shows the prefix for templates.

## Motivation and Context
Issue [496](https://github.com/Rise-Vision/viewer/issues/496)

## How Has This Been Tested?
Not yet tested

## Release Plan:
Release along with https://github.com/Rise-Vision/common-template/pull/163