### PR TITLE
remove logging

### DIFF
--- a/src/rise-helpers.js
+++ b/src/rise-helpers.js
@@ -168,12 +168,6 @@ RisePlayerConfiguration.Helpers = (() => {
       configuration = window.getRisePlayerConfiguration || window.top.getRisePlayerConfiguration;
     } catch ( err ) {
       console.log( err );
-
-      RisePlayerConfiguration.Viewer.sendEndpointLog({
-        severity: "DEBUG",
-        eventDetails: err && err.message
-      });
-
     }
 
     return configuration;


### PR DESCRIPTION
## Description
Fix stack overflow issue when getting component id from endpoint logging. The endpoint log call when getting new configuration was removed ( just console logging was left ).

## Motivation and Context
Escalated issue 03032021 resulted from a stack overflow that happened in Apps for template editor. Removing the endpoint logging effectively solves this issue in an easy way.

## How Has This Been Tested?
Tests are passing.

## Release Plan:
To be released immediately after approval, and it will be tested against displays and editor to confirm the error is solved.
The escalation channel will be notified of the fix.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation.

FYI @stulees @olegrise 
