### PR TITLE
Fix/issue 497 endpoint template logging

### DIFF
--- a/src/rise-logger.js
+++ b/src/rise-logger.js
@@ -247,7 +247,9 @@ RisePlayerConfiguration.Logger = (() => {
 
     // Some templates are logging errors as components. componentData.name
     // contains the template name.
-    const eventApp = componentData.name === templateData.name || !componentData.name ?
+    const isTemplateLog = componentData.name === templateData.name ||
+      !componentData.name || componentData.name === "RisePlayerConfiguration";
+    const eventApp = isTemplateLog ?
       `HTML Template: ${templateData.name}` :
       componentData.name;
 
@@ -256,7 +258,7 @@ RisePlayerConfiguration.Logger = (() => {
       eventErrorCode: ( eventDetails && eventDetails.errorCode ) || ( level === "error" ? "X" : null ),
       eventApp,
       componentId: componentData.id || null,
-      eventAppVersion: componentData.name ? componentData.version : templateData.version,
+      eventAppVersion: isTemplateLog ? templateData.version : componentData.version,
       eventDetails: JSON.stringify({ event, eventDetails }),
       debugInfo: JSON.stringify( Object.assign({}, additionalFields, { template: templateData }))
     });

--- a/test/unit/rise-logger/big-query.test.js
+++ b/test/unit/rise-logger/big-query.test.js
@@ -34,6 +34,8 @@ describe( "Big Query logging", function() {
     RisePlayerConfiguration.getPlayerInfo = undefined;
 
     sandbox = sinon.sandbox.create();
+    sandbox.stub( RisePlayerConfiguration, "getTemplateName" ).returns( "TEMPLATE-NAME" );
+    sandbox.stub( RisePlayerConfiguration, "getTemplateVersion" ).returns( "TEMPLATE-VERSION" );
     sandbox.stub( RisePlayerConfiguration.Helpers, "getWaitForPlayerURLParam" ).returns( false );
     sandbox.stub( RisePlayerConfiguration.Viewer, "sendEndpointLog" ).returns( false );
   });
@@ -446,6 +448,29 @@ describe( "Big Query logging", function() {
           expect( entry.source ).to.equal( COMPONENT_DATA.name );
           expect( entry.version ).to.equal( COMPONENT_DATA.version );
           expect( entry.component.id ).to.equal( COMPONENT_DATA.id );
+
+          const endpointCall = RisePlayerConfiguration.Viewer.sendEndpointLog
+          expect( endpointCall ).to.have.been.called;
+          expect( endpointCall.lastCall.args[ 0 ].eventApp ).to.equal( COMPONENT_DATA.name );
+          expect( endpointCall.lastCall.args[ 0 ].eventAppVersion ).to.equal( COMPONENT_DATA.version );
+          expect( endpointCall.lastCall.args[ 0 ].componentId ).to.equal( COMPONENT_DATA.id );
+        });
+
+        it( "should call endpoint log with HTML template event app for common template component", function() {
+          RisePlayerConfiguration.Logger.error({
+            name: "RisePlayerConfiguration",
+            id: "CommonComponent",
+            version: "N/A"
+          }, "common error" );
+
+          // Refresh token request + insert request
+          expect( requests.length ).to.equal( 2 );
+
+          const endpointCall = RisePlayerConfiguration.Viewer.sendEndpointLog
+          expect( endpointCall ).to.have.been.called;
+          expect( endpointCall.lastCall.args[ 0 ].eventApp ).to.equal( "HTML Template: TEMPLATE-NAME" );
+          expect( endpointCall.lastCall.args[ 0 ].eventAppVersion ).to.equal( "TEMPLATE-VERSION" );
+          expect( endpointCall.lastCall.args[ 0 ].componentId ).to.equal( "CommonComponent" );
         });
 
         it( "should log an error event with event details", function() {


### PR DESCRIPTION
## Description
Fixes issue 497 
https://github.com/Rise-Vision/viewer/issues/497

## Motivation and Context
Endpoint logging for code related to common-template will use the template eventApp by default, so it's easier to match to the template. The componentId can still reference the component that makes reporting. 

Full analysis here: https://trello.com/c/5VsUajO9/6361-template-errors-are-logged-with-riseplayerconfiguration-as-an-eventapp-name

Also, the reported eventAppVersion line was updated so it always match the version of either the template or the component. 

## How Has This Been Tested?
Unit tests were created for the common-template logging scenario, and checks where added to an existing unit test.
E2E tests are passing as in: https://app.circleci.com/pipelines/github/Rise-Vision/common-template/718/workflows/91f6a38f-70c6-43d9-b589-4534eb35976c

## Release Plan:
To be released to production after approval ( before Friday ).
The defect will be closed once it's verified working.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to udpated documentation.

FYI @stulees @olegrise 
